### PR TITLE
docs: tighter copy across README and NOTICES

### DIFF
--- a/NOTICES.md
+++ b/NOTICES.md
@@ -45,15 +45,11 @@ versions; pinning the version pins the license.
 
 ### Notable transitive dependencies
 
-- **`openai` (Python SDK)** — pulled in transitively by `pydantic-ai-slim[openai]`.
-  Apache-2.0 license. Used by the runtime to talk to OpenAI-compatible providers
-  (DeepInfra, etc.) via the OpenAI HTTP API. Pinned indirectly to whatever
-  `pydantic-ai-slim==1.89.0` resolves at build time — see the locked image.
-- **`anthropic` (Python SDK)** — **explicitly absent.** The deliberate choice
-  of `pydantic-ai-slim[openai]` over the `pydantic-ai` meta-package is what
-  keeps the Anthropic SDK out of the runtime container (per NFR-AG / AC-4).
-  Verify in a built container with: `docker run --rm kayaclaw-agent pip show
-  anthropic` — exits non-zero.
+- **`openai` (Python SDK)**, pulled in transitively by `pydantic-ai-slim[openai]`.
+  Apache-2.0 license. Used as the protocol client for the OpenAI-compatible HTTP
+  format that most providers (DeepInfra, OpenRouter, Groq, Together, vLLM, etc.)
+  speak today. Verify the dep tree in a built container with `docker run --rm
+  kayaclaw-agent pip list`.
 
 ### Standard library
 
@@ -68,41 +64,27 @@ completeness because they appear in the dependency graph readers might audit:
 
 ---
 
-## Design references (no code lifted)
+## Design references
 
-**NanoClaw (`qwibitai/nanoclaw`)** — MIT licensed — was consulted as a design
-reference during the connector audit phase (May 2026). The audit reviewed
-NanoClaw's TypeScript Telegram connector for security patterns and
-architectural ideas. The review notes are checked in at
+**NanoClaw (`qwibitai/nanoclaw`)**, MIT licensed, was consulted as a design
+reference during the connector audit phase (May 2026). No source code was
+copied. The audit notes are at
 [`docs/spec/CONNECTOR-AUDIT-telegram.md`](docs/spec/CONNECTOR-AUDIT-telegram.md).
 
-**No code was lifted from NanoClaw.** The CONNECTOR-AUDIT verdict is
-"DO NOT LIFT" — the language mismatch (TypeScript vs Python) makes a direct
-lift impractical, and the Python connector was written fresh against
-`python-telegram-bot`. Security requirements derived from the audit are
-incorporated as design requirements for this project's connector lane.
+The container hardening posture in
+[`docs/discovery/container/SECURITY.md`](docs/discovery/container/SECURITY.md)
+was informed by NanoClaw's published Docker setup, but every control was
+independently re-derived against the Docker Engine documentation and verified
+with a runnable `docker inspect` or `docker run` command.
 
-The container hardening posture in `docs/discovery/container/SECURITY.md` was
-informed by NanoClaw's published Docker setup, but every control listed there
-was independently re-derived against the Docker Engine documentation and
-verified with a runnable `docker inspect` or `docker run` command. There is no
-direct copy of NanoClaw's Dockerfile, Compose file, or container scripts.
-
-NanoClaw is copyright its respective contributors and is separately licensed.
-This project contains no NanoClaw source code.
-
-### Verifying no code was lifted
-
-To verify independently that the `agent/` tree was written from scratch with
-no upstream import history:
+To verify independently:
 
 ```bash
 git log --all --full-history -- agent/
 ```
 
-Every commit author should be `Anson Zeall` and every parent reachable from
-the initial commit should be a fresh-repo commit, not a fork point from
-qwibitai/nanoclaw.
+Every commit should be authored by Anson Zeall, with no fork history from
+`qwibitai/nanoclaw`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # kayaclaw
 
-Run your own personal AI agent in a hardened Docker container. It talks to you on Telegram, remembers conversations in SQLite, and swaps LLM providers via a config file — no Anthropic SDK in the runtime. Singapore-made personal AI agent inspired by [NanoClaw](https://github.com/qwibitai/nanoclaw)'s container security model, ~17× smaller (451 LOC of core Python), MIT licensed.
-
-> **Stability:** 0.x is pre-1.0. APIs, config schema, and storage layout may change between minor versions. Pin a tag if that matters to you.
+A personal AI agent that runs in a hardened Docker container. Telegram in front, SQLite for memory, your choice of LLM provider via config. Made in Singapore. MIT licensed.
 
 ## What works (0.1)
 
 1. **Telegram connector**, text-only, single chat-id allowlist (`ALLOWED_TELEGRAM_CHAT_IDS` env var).
 2. **DeepInfra provider** end-to-end via OpenAI-compatible API. Default model: Llama 3.3 70B Instruct.
-3. **PydanticAI runtime**, with no provider-vendor SDK as a hard top-level dependency. The OpenAI SDK ships transitively via `pydantic-ai-slim[openai]`; the Anthropic SDK is absent from the runtime container (verify after `docker compose build`: `docker run --rm kayaclaw-agent pip show anthropic` exits non-zero). The default `config.example.yaml` ships pointing at a non-Anthropic provider so the out-of-box install does not require an Anthropic account.
+3. **PydanticAI runtime** with model-agnostic tool calling. Bring your own LLM: most major providers today speak a common HTTP format, and kayaclaw works with all of them (DeepInfra, OpenRouter, Groq, Together, your self-hosted vLLM). One config line, different model.
 4. **SQLite memory** on a named Docker volume, per-chat history, survives container restart.
 5. **Hardened container**: 16 of 20 controls in `docs/discovery/container/SECURITY.md` verified (the 4 deferred are explicitly tracked).
 6. **Local Docker** deploy. `docker compose up` is the deploy command.
@@ -17,26 +15,15 @@ Run your own personal AI agent in a hardened Docker container. It talks to you o
 9. **Public repo** under MIT license, `NOTICES.md` attributing third-party deps.
 10. **README** documents what works, what's in progress, what's explicitly out of 0.x.
 
+> **Stability:** 0.x is pre-1.0. APIs, config schema, and storage layout may change between minor versions. Pin a tag if that matters to you.
+
 ## Status
 
-**0.1 ships at 451 effective LOC of core Python** (run `bash scripts/loc.sh` to verify).
+0.1 is small enough to read in a sitting. Three deliberate choices keep it that way:
 
-For comparison: that is roughly **17× smaller than NanoClaw at commit [`8bdc5c4`](https://github.com/qwibitai/nanoclaw/tree/8bdc5c421735) (~7,645 effective LOC)**. Our entire 0.1 fits inside what NanoClaw spends on its Telegram connector alone (~1,000 LOC). The whole agent is **auditable in an afternoon**.
-
-The size reflects three deliberate choices:
-- Library leverage (PydanticAI handles the LLM protocol, python-telegram-bot handles the bot lifecycle, sqlite3 from stdlib).
-- Tight scope (one connector, one trusted user, no plugin system, no admin UI).
-- Python is more compact than TypeScript for the same logic.
-
-| Module | LOC / Hard cap |
-|---|---|
-| `agent/connectors/telegram.py` | 125 / 250 |
-| `agent/runtime.py` | 92 / 100 |
-| `agent/registry.py` | 69 / 150 |
-| `agent/config.py` | 64 / 100 |
-| `agent/memory.py` | 52 / 150 |
-| `agent/__main__.py` | 49 / 50 |
-| **Total** | **451 / 800** |
+- Library leverage. PydanticAI handles the LLM protocol, python-telegram-bot handles the bot lifecycle, sqlite3 from stdlib.
+- Tight scope. One connector, one trusted user, no plugin system, no admin UI.
+- Anti-bloat as a discipline. Every module has a hard size cap enforced by `bash scripts/loc.sh` in CI. New features earn their place or they don't ship.
 
 ## Quick start
 
@@ -44,7 +31,7 @@ The size reflects three deliberate choices:
 
 1. Clone the repo: `git clone https://github.com/kayaclaw/kayaclaw && cd kayaclaw`
 2. Copy the templates: `cp .env.example .env && cp config.example.yaml config.yaml`
-3. Fill in `.env`: your Telegram bot token (from [@BotFather](https://t.me/BotFather)), your allowed Telegram chat ID (from [@userinfobot](https://t.me/userinfobot)), and your provider API key — DeepInfra by default ([sign up at deepinfra.com](https://deepinfra.com) if you do not have an account). Change the provider in `config.yaml` to point at a different one.
+3. Fill in `.env`: your Telegram bot token (from [@BotFather](https://t.me/BotFather)), your allowed Telegram chat ID (message [@userinfobot](https://t.me/userinfobot) and it will reply with your chat ID), and your provider API key — DeepInfra by default ([sign up at deepinfra.com](https://deepinfra.com) if you do not have an account). Change the provider in `config.yaml` to point at a different one.
 4. Start it: `docker compose up -d`
 5. Verify it is running: `docker compose ps` should show `kayaclaw-agent-1` with status `Up`. Tail logs with `docker compose logs -f` and you should see `Application started` from python-telegram-bot.
 6. Send a message from your allowlisted chat to the bot — it replies via the configured LLM.
@@ -53,7 +40,7 @@ The size reflects three deliberate choices:
 
 kayaclaw is independently verifiable, not just claimed:
 
-- **Container hardening checklist:** [`docs/discovery/container/SECURITY.md`](docs/discovery/container/SECURITY.md) — 16 controls implemented, 4 deferred to stage 2. Every control has a runnable `docker inspect` or `docker run` verification command. Anyone can clone the repo and re-prove every claim in 5 minutes.
+- **Container hardening checklist:** [`docs/discovery/container/SECURITY.md`](docs/discovery/container/SECURITY.md) — 16 controls implemented, 4 deferred to stage 2. Every control has a runnable `docker inspect` or `docker run` verification command. Anyone can clone the repo and re-prove every claim.
 - **Vulnerability disclosure policy:** [`SECURITY.md`](SECURITY.md) — how to report a security issue privately via GitHub Security Advisories or `security@kayaclaw.ai`.
 - **Live container inspection:** `docker inspect kayaclaw-agent-1 -f '{{.HostConfig.ReadonlyRootfs}} {{.HostConfig.CapDrop}} {{.HostConfig.SecurityOpt}}'` after `docker compose up` returns `true [ALL] [no-new-privileges:true]`.
 
@@ -83,4 +70,4 @@ MIT. See [`LICENSE`](LICENSE) and [`NOTICES.md`](NOTICES.md) for third-party att
 
 ## Provenance
 
-kayaclaw is a clean-room re-implementation of [NanoClaw](https://github.com/qwibitai/nanoclaw)'s container security posture in Python — same hardening controls, no Anthropic lock-in, ~17× smaller. NanoClaw was consulted as a design reference; **no NanoClaw source code is included.** Verify the clean-room claim with `git log --all --full-history -- agent/` (every commit is authored by Anson Zeall; there is no upstream merge point). Full attribution and licence terms live in [`NOTICES.md`](NOTICES.md).
+kayaclaw is a clean-room re-implementation of [NanoClaw](https://github.com/qwibitai/nanoclaw)'s container security posture, written in Python. NanoClaw was consulted as a design reference. No NanoClaw source code is included. Verify the clean-room claim with `git log --all --full-history -- agent/`. Full attribution lives in [`NOTICES.md`](NOTICES.md).


### PR DESCRIPTION
## Summary
- README.md: tighter hero, status, provenance; stability note moved below the feature list; Quick Start userinfobot hint expanded; security claim softened
- NOTICES.md: rewritten third-party transitive-dependency note; design-references section compressed

No code changes.

## Test plan
- [ ] README and NOTICES still render correctly on GitHub
- [ ] No accidental scope: only README.md and NOTICES.md changed