### PR TITLE
chore: cut v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to kayaclaw are documented in this file. Format follows Keep a Changelog (https://keepachangelog.com/en/1.1.0/). This project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2026-05-06
+
+### Added
+- Verified OpenRouter and Groq provider snippets in README and config.example.yaml. One config line, swap your LLM. ([#6](https://github.com/kayaclaw/kayaclaw/pull/6))
+
+## [0.1.0]
+
+Initial public release. See repository history.

--- a/agent/__about__.py
+++ b/agent/__about__.py
@@ -3,4 +3,4 @@
 # All other source files must use generic names (e.g. "agent").
 __brand__ = "kayaclaw"
 __slug__ = "kayaclaw"
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "kayaclaw"
-version = "0.1.0"
+version = "0.1.1"
 description = "kayaclaw — a Singapore-made, LLM-agnostic NanoClaw fork. Same security posture, no Anthropic lock-in."
 # `readme` field intentionally omitted in L0 — README.md is created in L6.
 # Add `readme = "README.md"` here as part of L6 release polish.


### PR DESCRIPTION
Bumps version to 0.1.1 and adds CHANGELOG.md. Tag and GitHub Release will follow once this is merged.