### PR TITLE
Add Anthropic Claude and Google Gemini examples; reframe "Switching providers" as any-model (v0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to kayaclaw are documented in this file. Format follows Keep a Changelog (https://keepachangelog.com/en/1.1.0/). This project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-05-06
+
+### Added
+- Anthropic Claude (sonnet-4.5) and Google Gemini (2.0 Flash) examples via OpenRouter in the README.
+
+### Changed
+- Reframed the "Switching providers" section to make explicit that any model the provider serves works, not just the ones shown.
+
 ## [0.1.1] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,11 +38,17 @@ A personal AI agent that runs in a hardened Docker container. Telegram in front,
 
 ## Switching providers
 
-kayaclaw works with any provider that speaks the OpenAI-compatible HTTP format. DeepInfra is the default. Two more are verified end-to-end and shown below.
+kayaclaw works with any provider that speaks the OpenAI-compatible HTTP format. Whatever model that provider offers, you can point your agent at it. The configs below are starting points. The same shape works for any other model the provider serves: list it in `allowed_models` and reference it in `agents.personal-assistant.model`.
+
+### DeepInfra (default)
+
+DeepInfra hosts open-source models on its own infrastructure. Sign up at [deepinfra.com](https://deepinfra.com), create an API key, set `DEEPINFRA_API_KEY` in your `.env`. The default config in `config.example.yaml` uses Llama 3.3 70B Instruct. Any model DeepInfra serves works the same way.
 
 ### OpenRouter
 
-OpenRouter routes to many upstream models. Sign up at [openrouter.ai](https://openrouter.ai), create an API key, then in `config.yaml`:
+OpenRouter routes to many upstream models from one OpenAI-compatible endpoint. Sign up at [openrouter.ai](https://openrouter.ai), create an API key, set `OPENROUTER_API_KEY` in your `.env`, then pick any model in `config.yaml`.
+
+Llama 3.3 70B Instruct:
 
 ```yaml
 providers:
@@ -61,11 +67,49 @@ agents:
       - telegram
 ```
 
-Set `OPENROUTER_API_KEY` in your `.env`. Verified with Llama 3.3 70B Instruct.
+Anthropic Claude (sonnet-4.5):
+
+```yaml
+providers:
+  openrouter:
+    kind: openai_compatible
+    base_url: https://openrouter.ai/api/v1
+    api_key_env: OPENROUTER_API_KEY
+    allowed_models:
+      - anthropic/claude-sonnet-4.5
+
+agents:
+  personal-assistant:
+    model: openrouter/anthropic/claude-sonnet-4.5
+    system_prompt: "You are a helpful assistant."
+    connectors:
+      - telegram
+```
+
+Google Gemini 2.0 Flash:
+
+```yaml
+providers:
+  openrouter:
+    kind: openai_compatible
+    base_url: https://openrouter.ai/api/v1
+    api_key_env: OPENROUTER_API_KEY
+    allowed_models:
+      - google/gemini-2.0-flash-001
+
+agents:
+  personal-assistant:
+    model: openrouter/google/gemini-2.0-flash-001
+    system_prompt: "You are a helpful assistant."
+    connectors:
+      - telegram
+```
+
+Any other OpenRouter-served model works the same way: list it in `allowed_models` and reference it in `agents.personal-assistant.model`.
 
 ### Groq
 
-Groq runs open-source models on its own inference hardware. Sign up at [console.groq.com](https://console.groq.com), create an API key, then in `config.yaml`:
+Groq runs open-source models on its own inference hardware. Sign up at [console.groq.com](https://console.groq.com), create an API key, set `GROQ_API_KEY` in your `.env`. Llama 3.3 70B Versatile:
 
 ```yaml
 providers:
@@ -84,7 +128,7 @@ agents:
       - telegram
 ```
 
-Set `GROQ_API_KEY` in your `.env`. Verified with Llama 3.3 70B Versatile.
+Any other Groq-served model works the same way.
 
 ## Verifying the security posture
 

--- a/agent/__about__.py
+++ b/agent/__about__.py
@@ -3,4 +3,4 @@
 # All other source files must use generic names (e.g. "agent").
 __brand__ = "kayaclaw"
 __slug__ = "kayaclaw"
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -38,6 +38,9 @@ providers:
   #   api_key_env: OPENROUTER_API_KEY
   #   allowed_models:
   #     - meta-llama/llama-3.3-70b-instruct
+  #     # any other OpenRouter-served model works the same way, e.g.:
+  #     # - anthropic/claude-sonnet-4.5
+  #     # - google/gemini-2.0-flash-001
   #
   # groq:
   #   kind: openai_compatible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "kayaclaw"
-version = "0.1.1"
+version = "0.1.2"
 description = "kayaclaw — a Singapore-made, LLM-agnostic NanoClaw fork. Same security posture, no Anthropic lock-in."
 # `readme` field intentionally omitted in L0 — README.md is created in L6.
 # Add `readme = "README.md"` here as part of L6 release polish.


### PR DESCRIPTION
Adds two more end-to-end verified configurations to the OpenRouter section in README: Anthropic Claude (sonnet-4.5) and Google Gemini (2.0 Flash). Both tested via the test bot before this PR.

Also reframes the section so it is explicit that any model the provider serves works the same way. The verified examples are proofs, not the boundary.

Bumps version to 0.1.2 and updates CHANGELOG. Tag and GitHub Release will follow once merged.