### PR TITLE
kayaclaw v0.1.3: impartial-default sweep + startup API key validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,27 @@
 # Copy this file to .env and fill in real values.
-# NEVER commit .env — it is gitignored.
+# NEVER commit .env. It is gitignored.
 # All values below are obviously fake placeholders.
 
-# Required — Telegram bot token from BotFather
+# Required. Telegram bot token from BotFather.
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token-here
 
-# Required — DeepInfra API key (matches api_key_env in config.yaml)
-DEEPINFRA_API_KEY=your-deepinfra-api-key-here
+# Required. Provider API key. The example ships with OpenRouter (one key
+# gets you many models). To use a different provider, comment OPENROUTER_API_KEY
+# out and uncomment the matching key below; then update config.yaml accordingly.
+OPENROUTER_API_KEY=your-openrouter-api-key-here
 
-# Required — comma-separated list of Telegram chat IDs permitted to use the bot.
+# Alternative provider keys (uncomment one to use it):
+# DEEPINFRA_API_KEY=your-deepinfra-api-key-here
+# GROQ_API_KEY=your-groq-api-key-here
+
+# Required. Comma-separated list of Telegram chat IDs permitted to use the bot.
 # In DMs, chat_id == user_id. Find yours by messaging @userinfobot.
 # Anyone NOT in this list is silently ignored (fail-closed). Empty list rejected.
 # Example format (not real IDs): 123456789,987654321
 ALLOWED_TELEGRAM_CHAT_IDS=your-chat-id-here
 
-# Optional — override the data directory; defaults to /data
+# Optional. Override the data directory; defaults to /data.
 # AGENT_DATA_DIR=/data
 
-# Optional — Python log level; defaults to INFO
+# Optional. Python log level; defaults to INFO.
 # LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
-# Secrets and live config — never commit these
+# Secrets and live config. Never commit these.
+# (.env.example IS committed; the patterns below carve out everything else.)
 .env
+.env.test
+.env.local
+.env.production
 config.yaml
+config.test.yaml
+config.local.yaml
 
 # Local data volume (SQLite, uploads)
 data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to kayaclaw are documented in this file. Format follows Keep a Changelog (https://keepachangelog.com/en/1.1.0/). This project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-05-07
+
+### Added
+- Startup validation: if a configured provider's `api_key_env` is missing or empty in the environment, the agent now exits at boot with a clear error naming the missing variable and the provider that referenced it. Previously the agent would boot successfully and only fail at the first user message.
+
+### Changed
+- Quick start section rewritten for clarity. Three setup steps split out, fewer pasted commands, log-tailing is now a debugging path rather than a verification step.
+- Default example provider switched from DeepInfra to OpenRouter. OpenRouter is itself a meta-provider (one key gets you Llama, Claude, Gemini, and more), which is a more impartial starting point. DeepInfra and Groq remain documented as alternatives.
+- `pyproject.toml` description rewritten to drop legacy framing.
+
 ## [0.1.2] - 2026-05-06
 
 ### Added

--- a/NOTICES.md
+++ b/NOTICES.md
@@ -57,7 +57,7 @@ The following are part of the Python 3.12 standard library and are governed by
 the [PSF License](https://docs.python.org/3/license.html). Listed here for
 completeness because they appear in the dependency graph readers might audit:
 
-- `sqlite3` — used by `agent/memory.py` for per-chat conversation history.
+- `sqlite3`. Used by `agent/memory.py` for per-chat conversation history.
   No third-party SQLite wrapper is taken as a top-level dependency
   (per DECISIONS.md D2).
 - `asyncio`, `logging`, `pathlib`, `os`, `threading`, `re`, `json`, `typing`.
@@ -94,11 +94,11 @@ The project's brand artwork was generated with AI image-generation tools, then
 post-processed with ImageMagick. Disclosed here in keeping with the
 project's brand commitment to transparency.
 
-- `assets/kayaclaw-logo.png` — chili-crab-and-kaya-toast mascot. Generated
+- `assets/kayaclaw-logo.png`. Chili-crab-and-kaya-toast mascot. Generated
   with Google Gemini Nano Banana (`gemini-3-pro-image-preview`), May 2026.
   Background knocked out to a true alpha channel via ImageMagick
   (`-fuzz 8% -transparent white`).
-- `assets/kayaclaw-social-preview.jpg` — 1280x640 Singapore-beach social
+- `assets/kayaclaw-social-preview.jpg`. 1280x640 Singapore-beach social
   preview banner (chili crab on a beach towel with a laptop, three
   unbranded AI mascot characters, Marina Bay Sands silhouette in the
   distance). Same generation method as the logo, then center-cropped from

--- a/README.md
+++ b/README.md
@@ -27,14 +27,31 @@ A personal AI agent that runs in a hardened Docker container. Telegram in front,
 
 ## Quick start
 
-**Prerequisite:** Docker 20.10+ with the Compose v2 plugin. Verify with `docker compose version` (should report `Docker Compose version v2.x` or newer).
+Prerequisite: Docker 20.10+ with the Compose v2 plugin. Verify with `docker compose version`.
 
-1. Clone the repo: `git clone https://github.com/kayaclaw/kayaclaw && cd kayaclaw`
-2. Copy the templates: `cp .env.example .env && cp config.example.yaml config.yaml`
-3. Fill in `.env`: your Telegram bot token (from [@BotFather](https://t.me/BotFather)), your allowed Telegram chat ID (message [@userinfobot](https://t.me/userinfobot) and it will reply with your chat ID), and your provider API key — DeepInfra by default ([sign up at deepinfra.com](https://deepinfra.com) if you do not have an account). Change the provider in `config.yaml` to point at a different one.
-4. Start it: `docker compose up -d`
-5. Verify it is running: `docker compose ps` should show `kayaclaw-agent-1` with status `Up`. Tail logs with `docker compose logs -f` and you should see `Application started` from python-telegram-bot.
-6. Send a message from your allowlisted chat to the bot — it replies via the configured LLM.
+Clone and copy the templates:
+
+```
+git clone https://github.com/kayaclaw/kayaclaw && cd kayaclaw
+cp .env.example .env
+cp config.example.yaml config.yaml
+```
+
+Fill in three values in `.env`:
+
+- `TELEGRAM_BOT_TOKEN` from [@BotFather](https://t.me/BotFather)
+- `ALLOWED_TELEGRAM_CHAT_IDS` from [@userinfobot](https://t.me/userinfobot)
+- `OPENROUTER_API_KEY` from [openrouter.ai](https://openrouter.ai). The example ships with OpenRouter as a starting point because one key gets you many models (Llama, Claude, Gemini, and more). You can swap to DeepInfra, Groq, or any OpenAI-compatible provider; see "Switching providers" below.
+
+Bring it up:
+
+```
+docker compose up -d
+```
+
+Send a message from your allowlisted Telegram chat. The bot replies via the configured LLM.
+
+If it doesn't reply, check the logs with `docker compose logs -f`. Stop with `docker compose down`.
 
 ## Switching providers
 
@@ -134,13 +151,13 @@ Any other Groq-served model works the same way.
 
 kayaclaw is independently verifiable, not just claimed:
 
-- **Container hardening checklist:** [`docs/discovery/container/SECURITY.md`](docs/discovery/container/SECURITY.md) — 16 controls implemented, 4 deferred to stage 2. Every control has a runnable `docker inspect` or `docker run` verification command. Anyone can clone the repo and re-prove every claim.
-- **Vulnerability disclosure policy:** [`SECURITY.md`](SECURITY.md) — how to report a security issue privately via GitHub Security Advisories or `security@kayaclaw.ai`.
+- **Container hardening checklist:** [`docs/discovery/container/SECURITY.md`](docs/discovery/container/SECURITY.md). 16 controls implemented, 4 deferred to stage 2. Every control has a runnable `docker inspect` or `docker run` verification command. Anyone can clone the repo and re-prove every claim.
+- **Vulnerability disclosure policy:** [`SECURITY.md`](SECURITY.md). How to report a security issue privately via GitHub Security Advisories or `security@kayaclaw.ai`.
 - **Live container inspection:** `docker inspect kayaclaw-agent-1 -f '{{.HostConfig.ReadonlyRootfs}} {{.HostConfig.CapDrop}} {{.HostConfig.SecurityOpt}}'` after `docker compose up` returns `true [ALL] [no-new-privileges:true]`.
 
 ## Where 1.x conversations start
 
-The following are deliberately out of scope for the 0.x line. The smallness is the value proposition — adding any of these without a clear case dilutes it. Open an issue if you want to make the case for one:
+The following are deliberately out of scope for the 0.x line. The smallness is the value proposition; adding any of these without a clear case dilutes it. Open an issue if you want to make the case for one:
 
 - Web UI / dashboard
 - Multi-user, multi-tenant, or multi-bot deployment
@@ -156,7 +173,7 @@ The following are deliberately out of scope for the 0.x line. The smallness is t
 
 ## Contributing
 
-Open an issue before sending a PR — describe what you want to change and why, and wait for a green light. Bug reports should include your OS, Docker version (`docker compose version`), and the relevant `docker compose logs` output.
+Open an issue before sending a PR. Describe what you want to change and why, and wait for a green light. Bug reports should include your OS, Docker version (`docker compose version`), and the relevant `docker compose logs` output.
 
 ## License
 

--- a/agent/__about__.py
+++ b/agent/__about__.py
@@ -3,4 +3,4 @@
 # All other source files must use generic names (e.g. "agent").
 __brand__ = "kayaclaw"
 __slug__ = "kayaclaw"
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -32,15 +32,31 @@ def main(config_path: Path = _DEFAULT_CONFIG_PATH) -> int:
                 f"Agent group 'personal-assistant' not found in config; "
                 f"defined groups: {list(config.agents.keys())}"
             )
-        resolved = resolve(config, agent_spec.model)
         # Drive secret registration from config, not env-var name patterns.
         # The L0 _collect_secrets() only catches *_API_KEY; a self-hoster
         # using OPENAI_TOKEN, GROQ_KEY, HF_TOKEN, etc. would otherwise
         # have their key NOT registered with the scrubber and could leak
         # in tracebacks (security-audit L5 P2-1).
-        for provider in config.providers.values():
-            if provider.api_key_env:
-                register_secret(os.environ.get(provider.api_key_env, ""))
+        #
+        # Validate every configured provider's api_key_env at startup,
+        # before resolve() picks the active model. resolve() also checks
+        # the active provider's key, but only that one. Validating ALL
+        # configured providers up front catches the "user switched
+        # providers and forgot to update .env" case AND the "user has
+        # a fallback provider configured but its key is missing" case.
+        # If you don't intend to use a provider, comment it out.
+        for provider_name, provider in config.providers.items():
+            if not provider.api_key_env:
+                continue
+            api_key = os.environ.get(provider.api_key_env, "").strip()
+            if not api_key:
+                raise ConfigError(
+                    f"Missing API key: env var '{provider.api_key_env}' "
+                    f"(referenced by provider '{provider_name}' in "
+                    f"config.yaml) is not set or is empty"
+                )
+            register_secret(api_key)
+        resolved = resolve(config, agent_spec.model)
     except (ConfigError, NotImplementedError) as e:
         log.critical("Startup failed: %s", e)
         return 1

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,46 +1,51 @@
-# config.example.yaml — committed template for the agent configuration.
+# config.example.yaml. Committed template for the agent configuration.
 # The live config.yaml (which contains real API keys and customised settings)
 # is gitignored and derived from this file. Copy this file to config.yaml and
 # fill in your values before running the agent.
 
 providers:
-  # Provider registry key — used as the prefix in agent model references
-  # (e.g. "deepinfra/meta-llama/Llama-3.3-70B-Instruct").
-  deepinfra:
+  # Provider registry key. Used as the prefix in agent model references
+  # (e.g. "openrouter/meta-llama/llama-3.3-70b-instruct").
+  #
+  # The example below uses OpenRouter as a starting point because one key
+  # gets you many models. To switch providers, comment this block out and
+  # uncomment one of the alternatives below. See "Switching providers"
+  # in the README.
+  openrouter:
     # kind: which client protocol this provider speaks.
-    # "openai_compatible" — uses the OpenAI-compatible REST API (base_url required).
-    # "anthropic"         — Anthropic native API (not yet supported in 0.1).
+    # "openai_compatible". Uses the OpenAI-compatible REST API (base_url required).
+    # "anthropic". Anthropic native API (not yet supported in 0.1).
     kind: openai_compatible
 
     # base_url: required when kind is openai_compatible.
     # This is the root URL of the provider's OpenAI-compatible endpoint.
-    base_url: https://api.deepinfra.com/v1/openai
+    base_url: https://openrouter.ai/api/v1
 
     # api_key_env: the NAME of the environment variable that holds the API key.
-    # The key value is never stored here — only the variable name.
+    # The key value is never stored here. Only the variable name.
     # Set the actual key in your shell or .env file.
-    api_key_env: DEEPINFRA_API_KEY
+    api_key_env: OPENROUTER_API_KEY
 
     # allowed_models: which models this provider is permitted to serve.
     # DENY-by-default semantics:
-    #   []      — deny all models (operator must explicitly list each one)
-    #   ["*"]   — any model is allowed (escape hatch; use only if you trust the provider fully)
-    #   [a, b]  — exact match required; only listed model IDs are routed to this provider
+    #   []      = deny all models (operator must explicitly list each one)
+    #   ["*"]   = any model is allowed (escape hatch; use only if you trust the provider fully)
+    #   [a, b]  = exact match required; only listed model IDs are routed to this provider
     allowed_models:
-      - meta-llama/Llama-3.3-70B-Instruct
+      - meta-llama/llama-3.3-70b-instruct
+      # Any other OpenRouter-served model works the same way, e.g.:
+      # - anthropic/claude-sonnet-4.5
+      # - google/gemini-2.0-flash-001
 
-  # Alternative provider examples (verified). Uncomment one to use it,
+  # Alternative providers (verified). Uncomment one to use it,
   # and update the agents.personal-assistant.model line below.
   #
-  # openrouter:
+  # deepinfra:
   #   kind: openai_compatible
-  #   base_url: https://openrouter.ai/api/v1
-  #   api_key_env: OPENROUTER_API_KEY
+  #   base_url: https://api.deepinfra.com/v1/openai
+  #   api_key_env: DEEPINFRA_API_KEY
   #   allowed_models:
-  #     - meta-llama/llama-3.3-70b-instruct
-  #     # any other OpenRouter-served model works the same way, e.g.:
-  #     # - anthropic/claude-sonnet-4.5
-  #     # - google/gemini-2.0-flash-001
+  #     - meta-llama/Llama-3.3-70B-Instruct
   #
   # groq:
   #   kind: openai_compatible
@@ -50,14 +55,14 @@ providers:
   #     - llama-3.3-70b-versatile
 
 agents:
-  # Agent group key — referenced in connector configuration to select which
+  # Agent group key. Referenced in connector configuration to select which
   # group handles incoming messages.
   personal-assistant:
-    # model: "<provider>/<model-id>" — the slash is mandatory.
+    # model: "<provider>/<model-id>". The slash is mandatory.
     # The provider part must match a key in the providers section above.
     # The model-id part must appear in that provider's allowed_models list
     # (or allowed_models must contain "*").
-    model: deepinfra/meta-llama/Llama-3.3-70B-Instruct
+    model: openrouter/meta-llama/llama-3.3-70b-instruct
 
     # system_prompt: the system instruction sent to the model on every turn.
     system_prompt: "You are a helpful assistant."

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,0 +1,47 @@
+# docker-compose.test.yaml — kayaclaw_tian_bot test harness.
+# Untracked, gitignored. Not meant for production. Used to verify a kayaclaw
+# build end-to-end against a Telegram bot whose token we are happy to expose
+# to a development image, before any change to the runtime path is pushed.
+#
+# Run with:  docker compose -f docker-compose.test.yaml --env-file .env.test up
+# Stop with: docker compose -f docker-compose.test.yaml down
+
+services:
+  agent:
+    build: .
+    image: kayaclaw:test
+    restart: "no"
+    read_only: true
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      - TELEGRAM_BOT_TOKEN
+      - ALLOWED_TELEGRAM_CHAT_IDS
+      - OPENROUTER_API_KEY
+      - DEEPINFRA_API_KEY
+      - GROQ_API_KEY
+      - AGENT_DATA_DIR=${AGENT_DATA_DIR:-/data}
+      - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
+    volumes:
+      - agent-test-data:/data
+      - ./config.test.yaml:/config/config.yaml:ro
+    tmpfs:
+      - /tmp:mode=1777,noexec,nosuid,nodev,size=64m
+    networks:
+      - agent-test-net
+    cpus: 1.0
+    mem_limit: 512m
+    pids_limit: 100
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+networks:
+  agent-test-net:
+    driver: bridge
+
+volumes:
+  agent-test-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,13 @@ services:
       # SECURITY.md control 14. See .env.example for the required keys.
       - TELEGRAM_BOT_TOKEN
       - ALLOWED_TELEGRAM_CHAT_IDS      # eng-review L5 P1-1: chat_id, NOT user_id
+      # Provider API keys. Forward all three of the documented providers;
+      # the agent's startup validation only enforces presence for keys
+      # referenced by an active provider in config.yaml, so unused keys
+      # being unset is fine.
+      - OPENROUTER_API_KEY
       - DEEPINFRA_API_KEY
+      - GROQ_API_KEY
       # Config knobs (not secrets) — ${VAR:-default} lets .env override
       # while preserving a sensible default. codex-review L5-Step3 P1: a
       # bare `KEY=value` form would block .env overrides entirely.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "kayaclaw"
-version = "0.1.2"
-description = "kayaclaw — a Singapore-made, LLM-agnostic NanoClaw fork. Same security posture, no Anthropic lock-in."
-# `readme` field intentionally omitted in L0 — README.md is created in L6.
+version = "0.1.3"
+description = "A small, hardened AI agent for Telegram. SQLite memory, your choice of OpenAI-compatible LLM provider."
+# `readme` field intentionally omitted in L0. README.md is created in L6.
 # Add `readme = "README.md"` here as part of L6 release polish.
 license = {text = "MIT"}
 requires-python = ">=3.12"
@@ -16,7 +16,7 @@ dependencies = [
     # anthropic + openai + every provider SDK transitively, which violates
     # AC-4 ("zero Anthropic surface in the deployed agent"). The [openai]
     # extra installs only the OpenAI-compatible provider stack we actually
-    # use. Discovered during L5 Step 2 acceptance testing — anthropic 0.97.0
+    # use. Discovered during L5 Step 2 acceptance testing: anthropic 0.97.0
     # was reachable inside the container despite the kayaclaw spec requiring
     # zero Anthropic surface. (NFR-AG.)
     "pydantic-ai-slim[openai]==1.89.0",
@@ -25,13 +25,13 @@ dependencies = [
 ]
 
 [project.scripts]
-# `entrypoint.sh` calls `exec agent` inside the container — that resolves
+# `entrypoint.sh` calls `exec agent` inside the container. That resolves
 # to this entry point after pip-install. Added in L5 Step 1 (eng-review P2-1).
 agent = "agent.__main__:main"
 
 [tool.flit.module]
 # The distribution name is `kayaclaw` (PyPI / branding) but the import path
 # is `agent` (NFR-BD2: no brand in import paths). Point flit at the actual
-# package folder. Added in L5 Step 2 — without this, `pip install .` fails
+# package folder. Added in L5 Step 2. Without this, `pip install .` fails
 # with "No file/folder found for module kayaclaw".
 name = "agent"

--- a/tests/test_l1_config_registry.py
+++ b/tests/test_l1_config_registry.py
@@ -175,22 +175,22 @@ def _make_config(provider_override: dict | None = None) -> Config:
 
 def test_resolve_happy_path(monkeypatch):
     """Happy path: resolve known model with API key set returns ResolvedProvider."""
-    monkeypatch.setenv("DEEPINFRA_API_KEY", "test-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     config = load_config(_EXAMPLE_CONFIG)
-    result = resolve(config, "deepinfra/meta-llama/Llama-3.3-70B-Instruct")
+    result = resolve(config, "openrouter/meta-llama/llama-3.3-70b-instruct")
     assert isinstance(result, ResolvedProvider)
-    assert result.provider_name == "deepinfra"
+    assert result.provider_name == "openrouter"
     assert result.kind == "openai_compatible"
-    assert result.model_id == "meta-llama/Llama-3.3-70B-Instruct"
+    assert result.model_id == "meta-llama/llama-3.3-70b-instruct"
     assert result.api_key == "test-key"
 
 
 def test_resolve_provider_name_populated(monkeypatch):
     """P2-4: provider_name field is set to the registry key, not the kind."""
-    monkeypatch.setenv("DEEPINFRA_API_KEY", "test-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     config = load_config(_EXAMPLE_CONFIG)
-    result = resolve(config, "deepinfra/meta-llama/Llama-3.3-70B-Instruct")
-    assert result.provider_name == "deepinfra"
+    result = resolve(config, "openrouter/meta-llama/llama-3.3-70b-instruct")
+    assert result.provider_name == "openrouter"
 
 
 def test_resolve_unknown_provider_raises_config_error():
@@ -205,15 +205,15 @@ def test_resolve_unknown_provider_raises_config_error():
 
 def test_resolve_disallowed_model_raises_config_error(monkeypatch):
     """Model not in allowed_models raises ConfigError naming model and allowed list."""
-    monkeypatch.setenv("DEEPINFRA_API_KEY", "test-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     config = load_config(_EXAMPLE_CONFIG)
     with pytest.raises(ConfigError) as excinfo:
-        resolve(config, "deepinfra/gpt-4o")
+        resolve(config, "openrouter/gpt-4o")
     err = str(excinfo.value)
     assert err  # non-empty
     assert "gpt-4o" in err
     # Should also mention what IS allowed so operator can diagnose
-    assert "meta-llama/Llama-3.3-70B-Instruct" in err
+    assert "meta-llama/llama-3.3-70b-instruct" in err
 
 
 def test_resolve_empty_allowed_models_denies_all(monkeypatch):
@@ -236,13 +236,13 @@ def test_resolve_wildcard_allows_any(monkeypatch):
 
 def test_resolve_missing_api_key_raises_config_error(monkeypatch):
     """Missing API key env var raises ConfigError naming the variable."""
-    monkeypatch.delenv("DEEPINFRA_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     config = load_config(_EXAMPLE_CONFIG)
     with pytest.raises(ConfigError) as excinfo:
-        resolve(config, "deepinfra/meta-llama/Llama-3.3-70B-Instruct")
+        resolve(config, "openrouter/meta-llama/llama-3.3-70b-instruct")
     err = str(excinfo.value)
     assert err  # non-empty
-    assert "DEEPINFRA_API_KEY" in err
+    assert "OPENROUTER_API_KEY" in err
 
 
 def test_resolve_anthropic_raises_not_implemented():
@@ -277,11 +277,11 @@ def test_resolve_config_error_messages_are_nonempty(monkeypatch):
 
     # Disallowed model (key not needed — fails before step 4)
     with pytest.raises(ConfigError) as exc:
-        resolve(config, "deepinfra/not-allowed-model")
+        resolve(config, "openrouter/not-allowed-model")
     assert str(exc.value)
 
     # Missing API key
-    monkeypatch.delenv("DEEPINFRA_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     with pytest.raises(ConfigError) as exc:
-        resolve(config, "deepinfra/meta-llama/Llama-3.3-70B-Instruct")
+        resolve(config, "openrouter/meta-llama/llama-3.3-70b-instruct")
     assert str(exc.value)

--- a/tests/test_l5_container.py
+++ b/tests/test_l5_container.py
@@ -82,6 +82,45 @@ class TestMainProviderResolve:
         assert any("Startup failed" in r.getMessage() for r in caplog.records)
 
 
+class TestMainApiKeyValidation:
+    def test_missing_api_key_returns_1_with_clear_message(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Provider's api_key_env not set in env → ConfigError → exit 1.
+
+        Catches the case where a user switches providers in config.yaml
+        but forgets to set the matching API key in .env. Without this
+        validation the agent boots and only fails at the first user message.
+        """
+        cfg = _write_config(tmp_path)
+        monkeypatch.delenv("DEEPINFRA_API_KEY", raising=False)
+        with caplog.at_level(logging.CRITICAL, logger="agent.main"):
+            rc = main_mod.main(cfg)
+        assert rc == 1
+        msgs = " ".join(r.getMessage() for r in caplog.records)
+        assert "Missing API key" in msgs
+        assert "DEEPINFRA_API_KEY" in msgs
+        assert "deepinfra" in msgs
+
+    def test_empty_api_key_returns_1(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An api_key_env set to empty string is treated as missing."""
+        cfg = _write_config(tmp_path)
+        monkeypatch.setenv("DEEPINFRA_API_KEY", "   ")
+        with caplog.at_level(logging.CRITICAL, logger="agent.main"):
+            rc = main_mod.main(cfg)
+        assert rc == 1
+        msgs = " ".join(r.getMessage() for r in caplog.records)
+        assert "Missing API key" in msgs
+
+
 class TestMainStartupLogging:
     def test_startup_log_contains_provider_and_model(
         self,


### PR DESCRIPTION
## Summary
- Public copy and example config switched to OpenRouter as the starting provider, framed as "starting example, not preference."
- New runtime: every configured provider's API key is validated at startup; missing or empty keys fail fast with a clear error.

## Test plan
- [x] Independent code review on the diff: no P1/P2 issues
- [x] End-to-end smoke test: Llama via OpenRouter, bot replied
- [x] tests/test_l5_container.py adds coverage for missing + empty API key paths
- [x] Existing tests refreshed against the new example config; full suite (117 tests) passes