### PR TITLE
feat: provider/model fallback chain (v0.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to kayaclaw are documented in this file. Format follows Keep a Changelog (https://keepachangelog.com/en/1.1.0/). This project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-05-08
+
+### Added
+- Optional `fallback:` config field. List up to 5 `<provider>/<model-id>` alternates tried in order when the primary call fails. Duplicates and primary-model cycles are rejected at config load. On full exhaustion, the bot replies with a user-visible status message and the failure summary is logged. Empty or omitted keeps prior behaviour.
+
 ## [0.1.3] - 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -147,6 +147,20 @@ agents:
 
 Any other Groq-served model works the same way.
 
+### Fallback chain
+
+If the primary LLM call fails, kayaclaw can try alternates in order. Each entry uses the same `<provider>/<model-id>` shape as `agents.<group>.model`. The provider key must already exist in `providers:` and the model must be in that provider's `allowed_models`. Add a top-level `fallback:` block to `config.yaml`:
+
+```yaml
+fallback:
+  - groq/llama-3.3-70b-versatile
+  - deepinfra/meta-llama/Llama-3.3-70B-Instruct
+```
+
+Order matters; capped at 5 entries. Every attempt is a billable LLM call.
+
+When the whole chain is exhausted on a single user message, the bot replies once with `"Having trouble reaching the LLM right now, please try again in a minute."` and logs the failure summary at CRITICAL.
+
 ## Verifying the security posture
 
 kayaclaw is independently verifiable, not just claimed:
@@ -164,7 +178,7 @@ The following are deliberately out of scope for the 0.x line. The smallness is t
 - WhatsApp, Slack, Discord, Gmail connectors
 - Tool / function calling beyond a text reply (no file ops, web search, bash-in-container)
 - Scheduled jobs / cron
-- Cost-based provider routing, fallback chains, or per-message routing
+- Cost-based provider routing or per-message routing
 - VPS deployment automation
 - Streaming responses
 - Vector recall / RAG

--- a/agent/__about__.py
+++ b/agent/__about__.py
@@ -3,4 +3,4 @@
 # All other source files must use generic names (e.g. "agent").
 __brand__ = "kayaclaw"
 __slug__ = "kayaclaw"
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -57,13 +57,18 @@ def main(config_path: Path = _DEFAULT_CONFIG_PATH) -> int:
                 )
             register_secret(api_key)
         resolved = resolve(config, agent_spec.model)
+        # Resolve the optional fallback chain. resolve() raises ConfigError
+        # for unknown provider, disallowed model, or unsupported kind, so
+        # the surrounding try/except already turns those into a CRITICAL
+        # log + exit 1 with a clear message.
+        resolved_fallbacks = [resolve(config, ref) for ref in config.fallback]
     except (ConfigError, NotImplementedError) as e:
         log.critical("Startup failed: %s", e)
         return 1
 
     log.info(
-        "Agent starting: provider=%s model=%s connector=telegram",
-        resolved.provider_name, resolved.model_id,
+        "Agent starting: provider=%s model=%s connector=telegram fallback_len=%d",
+        resolved.provider_name, resolved.model_id, len(resolved_fallbacks),
     )
     try:
         memory = Memory(default_db_path())
@@ -72,7 +77,7 @@ def main(config_path: Path = _DEFAULT_CONFIG_PATH) -> int:
         return 1
 
     try:
-        connector_run(config, resolve, memory)
+        connector_run(config, resolve, memory, resolved_fallbacks)
     except (KeyboardInterrupt, SystemExit):
         log.info("Agent stopped")
     return 0

--- a/agent/config.py
+++ b/agent/config.py
@@ -60,11 +60,56 @@ class AgentGroupSpec(BaseModel):
         return v
 
 
+FALLBACK_MAX_LENGTH = 5
+
+
 class Config(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     providers: dict[str, ProviderSpec]
     agents: dict[str, AgentGroupSpec]
+    # Optional per-deployment fallback chain. Each entry is a "<provider>/<model-id>"
+    # reference tried in declared order if the active agent's primary call fails.
+    # Empty / missing = no fallback (v0.1.3 behavior).
+    fallback: list[str] = []
+
+    @field_validator("fallback")
+    @classmethod
+    def _fallback_entries_have_slash(cls, v: list[str]) -> list[str]:
+        for entry in v:
+            parts = entry.split("/", 1)
+            if len(parts) != 2 or not parts[0] or not parts[1]:
+                raise ValueError(
+                    f'fallback entry {entry!r} must be in "<provider>/<model-id>" format'
+                )
+        return v
+
+    @model_validator(mode="after")
+    def _fallback_invariants(self) -> "Config":
+        if len(self.fallback) > FALLBACK_MAX_LENGTH:
+            raise ValueError(
+                f"fallback list length {len(self.fallback)} exceeds the cap "
+                f"of {FALLBACK_MAX_LENGTH}; if you need a longer chain, "
+                f"reconsider whether the providers are right"
+            )
+        seen: set[str] = set()
+        for entry in self.fallback:
+            if entry in seen:
+                raise ValueError(
+                    f"fallback list contains duplicate entry {entry!r}; "
+                    f"each provider/model reference must appear at most once"
+                )
+            seen.add(entry)
+        agent_models = {spec.model for spec in self.agents.values()}
+        cycle = seen & agent_models
+        if cycle:
+            offending = sorted(cycle)[0]
+            raise ValueError(
+                f"fallback entry {offending!r} duplicates an agent's primary model; "
+                f"a fallback to the same provider/model retries the failing call "
+                f"and wastes cost"
+            )
+        return self
 
 
 def load_config(path: Path) -> Config:

--- a/agent/connectors/telegram.py
+++ b/agent/connectors/telegram.py
@@ -89,6 +89,7 @@ def _make_handler(
     resolved: ResolvedProvider,
     system_prompt: str,
     memory: Memory,
+    fallbacks: list[ResolvedProvider] | None = None,
 ):
     """Build the inbound-message handler closure.
 
@@ -120,9 +121,25 @@ def _make_handler(
 
             memory.append(chat_id, "user", text)
             history = memory.history(chat_id)
-            reply_text = await runtime.reply(
-                resolved, system_prompt, history, text, chat_id
-            )
+            try:
+                reply_text = await runtime.reply_with_fallback(
+                    resolved, fallbacks or [], system_prompt, history, text, chat_id
+                )
+            except runtime.AllProvidersFailed:
+                # Every configured provider failed. Send a single user-visible
+                # status line and persist nothing. The CRITICAL log inside
+                # reply_with_fallback already recorded the chain.
+                outbound = (
+                    "Having trouble reaching the LLM right now, "
+                    "please try again in a minute."
+                )
+                await message.reply_text(outbound)
+                _log.info(
+                    "reply-fallback-exhausted: chat_id=%d reply_len=%d",
+                    chat_id,
+                    len(outbound),
+                )
+                return
             # Truncate BEFORE persisting + sending so memory matches what the
             # user saw. If we appended the full LLM reply and only truncated
             # the send, the next turn would re-condition on the long text and
@@ -145,6 +162,7 @@ def run(
     config: Config,
     registry_resolver: Callable[[Config, str], ResolvedProvider],
     memory: Memory,
+    fallbacks: list[ResolvedProvider] | None = None,
 ) -> None:
     """Long-running Telegram polling loop.
 
@@ -170,14 +188,17 @@ def run(
 
     # No token in this log line. Counts and identifiers only.
     _log.info(
-        "Connector starting: provider=%s model=%s allowlist_size=%d",
+        "Connector starting: provider=%s model=%s allowlist_size=%d fallback_len=%d",
         resolved.provider_name,
         resolved.model_id,
         len(allowlist),
+        len(fallbacks or []),
     )
 
     app = ApplicationBuilder().token(token).build()
-    handler = _make_handler(allowlist, resolved, agent_spec.system_prompt, memory)
+    handler = _make_handler(
+        allowlist, resolved, agent_spec.system_prompt, memory, fallbacks
+    )
     # filters.TEXT IS the 5MB attachment-size cap mechanism for 0.1 — non-text
     # is dropped before any handler runs (eng-review A3).
     app.add_handler(MessageHandler(filters.TEXT & (~filters.COMMAND), handler))

--- a/agent/runtime.py
+++ b/agent/runtime.py
@@ -15,6 +15,23 @@ from agent.registry import ResolvedProvider
 _log = get_logger("agent.runtime")
 
 
+class AllProvidersFailed(Exception):
+    """Raised by reply_with_fallback when the primary AND every fallback fails.
+
+    `attempts` carries (provider_name, model_id, exception_class_name) for each
+    attempt in order. The original exceptions are preserved on `__cause__`
+    chains for tracebacks; the public `attempts` field is intentionally
+    text-only to avoid leaking exception bodies into logs or error responses.
+    """
+
+    def __init__(self, attempts: list[tuple[str, str, str]]):
+        self.attempts = attempts
+        summary = "; ".join(f"{p}/{m}: {cls}" for p, m, cls in attempts)
+        super().__init__(
+            f"All {len(attempts)} provider(s) failed. Chain: {summary}"
+        )
+
+
 class Turn(TypedDict):
     """A single conversation turn, compatible with the L3 memory layer's dict shape."""
 
@@ -109,3 +126,57 @@ async def reply(
             exc_info=True,
         )
         raise
+
+
+async def reply_with_fallback(
+    primary: ResolvedProvider,
+    fallbacks: list[ResolvedProvider],
+    system_prompt: str,
+    history: list[Turn],
+    user_text: str,
+    chat_id: int,
+) -> str:
+    """Same shape as reply(), but cycles through a primary + fallback chain.
+
+    AC-1: when fallbacks is empty, this is a thin passthrough to reply()
+    and the empty-fallback path stays byte-for-byte identical to v0.1.3.
+
+    Otherwise: try each entry in [primary, *fallbacks]. On any exception,
+    log INFO with the failing entry, the next entry (if any) and the
+    exception CLASS NAME ONLY (no str(exc), to avoid leaking request bodies
+    or secrets), then continue. On exhaustion, raise AllProvidersFailed
+    with the per-attempt class-name summary.
+    """
+    if not fallbacks:
+        return await reply(primary, system_prompt, history, user_text, chat_id)
+
+    chain: list[ResolvedProvider] = [primary, *fallbacks]
+    attempts: list[tuple[str, str, str]] = []
+    last_exc: Exception | None = None
+
+    for idx, prov in enumerate(chain):
+        try:
+            return await reply(prov, system_prompt, history, user_text, chat_id)
+        except Exception as exc:
+            last_exc = exc
+            cls_name = type(exc).__name__
+            attempts.append((prov.provider_name, prov.model_id, cls_name))
+            if idx + 1 < len(chain):
+                nxt = chain[idx + 1]
+                _log.info(
+                    "fallback: %s/%s -> %s/%s (cause=%s)",
+                    prov.provider_name,
+                    prov.model_id,
+                    nxt.provider_name,
+                    nxt.model_id,
+                    cls_name,
+                )
+
+    summary = "; ".join(f"{p}/{m}: {cls}" for p, m, cls in attempts)
+    _log.critical("All providers in fallback chain failed: %s", summary)
+    # Chain the final provider's exception via `from` so the traceback
+    # preserves the root cause for debugging (codex-review v0.1.4 P2).
+    # The CRITICAL log line above is class-names-only for secret hygiene;
+    # the `from` chain is for stderr tracebacks where the L0 scrubber
+    # already redacts known secrets.
+    raise AllProvidersFailed(attempts) from last_exc

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -71,3 +71,22 @@ agents:
     # In 0.1 only "telegram" is a valid connector.
     connectors:
       - telegram
+
+# Optional: provider/model fallback chain.
+# If the active agent's primary call fails, kayaclaw tries each entry below
+# in declared order and uses the first one that returns a reply. Entries
+# share the same "<provider>/<model-id>" shape as agents.<group>.model and
+# the model must appear in that provider's allowed_models list.
+#
+# Order matters. Cost note: every fallback attempt is a billable LLM call.
+# Capped at 5 entries. The list may not contain duplicates, and may not
+# reference the same provider/model as any agent's primary (that would
+# just retry the failing call).
+#
+# Empty or omitted = no fallback (the v0.1.3 behaviour).
+#
+# fallback:
+#   # Both providers below are commented out by default in this file.
+#   # Uncomment them in the providers: section above before adding them here.
+#   - groq/llama-3.3-70b-versatile
+#   - deepinfra/meta-llama/Llama-3.3-70B-Instruct

--- a/docs/impl/PLAN-v0.1.4-fallback.md
+++ b/docs/impl/PLAN-v0.1.4-fallback.md
@@ -1,0 +1,223 @@
+# PLAN — v0.1.4 provider/model fallback
+
+References: SPEC-v0.1.4-fallback.md, Trello #40
+Status: draft, awaiting /plan-eng-review
+
+## Summary of approach
+
+Add a thin wrapper around `agent.runtime.reply()` that takes a list of `ResolvedProvider` instances (primary + fallbacks). Iterate them in order. On each exception from `reply()`, log the failure and try the next. On exhaustion, raise a new `AllProvidersFailed` exception that the connector translates into the user-visible "having trouble" message.
+
+The new function lives in agent/runtime.py beside `reply()`. The existing `reply()` is unchanged.
+
+Config: add an optional top-level `fallback: list[str]` to `Config`. Resolve each entry to a `ResolvedProvider` at startup using the existing `resolve()` from agent.registry. The 0.1.3 startup-key validation already covers each provider's api_key_env presence.
+
+The connector code change is one line: pass `[primary] + fallbacks` to the new wrapper instead of calling `reply()` directly.
+
+## Architecture
+
+```
+config.yaml
+  providers: {openrouter, groq, deepinfra}
+  agents.personal-assistant.model: openrouter/llama
+  fallback: [groq/llama, deepinfra/llama]   # NEW
+
+  ↓ load_config()
+
+Config object
+  .agents["personal-assistant"].model = "openrouter/llama"
+  .fallback = ["groq/llama", "deepinfra/llama"]   # NEW
+
+  ↓ __main__.main()
+
+resolved_primary = resolve(config, agent_spec.model)
+resolved_fallbacks = [resolve(config, ref) for ref in config.fallback]   # NEW
+
+  ↓ connector_run(config, resolve, memory)
+
+  ↓ telegram.handle_message()
+
+reply_text = await reply_with_fallback(   # NEW (was: reply(...))
+    primary=resolved_primary,
+    fallbacks=resolved_fallbacks,
+    system_prompt=...,
+    history=...,
+    user_text=...,
+    chat_id=...,
+)
+```
+
+## Step-by-step implementation
+
+### Step 1 — Config schema for `fallback`
+
+Files: `agent/config.py`
+LOC budget: ~50
+
+- Add `fallback: list[str] = []` to the `Config` Pydantic model with a field validator that:
+  - Each entry is a non-empty string of the form `<provider>/<model-id>` (the resolver will do deeper validation, this is just shape-level).
+  - The list is allowed to be empty or missing.
+- Add a model-level validator (post `agents` and `fallback`):
+  - Length cap: `len(fallback) <= 5`. ConfigError if exceeded.
+  - No duplicates within `fallback` itself. ConfigError naming the dupe.
+  - For each agent that has a `model`, no entry in `fallback` may equal that agent's model. ConfigError naming the conflicting entry.
+- No change to `load_config()` other than letting Pydantic populate the new field.
+
+### Step 2 — Startup resolution + validation
+
+Files: `agent/__main__.py`
+LOC budget: ~15
+
+- After resolving the primary, iterate `config.fallback` and call `resolve(config, ref)` for each. Collect into `resolved_fallbacks: list[ResolvedProvider]`.
+- Any `ConfigError` from `resolve()` propagates out; existing `except (ConfigError, NotImplementedError)` block already turns it into CRITICAL log + exit 1 with a clear message.
+- Pass `resolved_fallbacks` into the connector's run signature (Step 3).
+
+### Step 3 — `reply_with_fallback` function
+
+Files: `agent/runtime.py`, `tests/test_l2_runtime.py`
+LOC budget: ~80 (function + 5 tests)
+
+- New module-level exception `AllProvidersFailed(Exception)` with `attempts: list[tuple[str, str, BaseException]]` summarizing each (provider, model, error) tried.
+- New async function:
+
+```python
+async def reply_with_fallback(
+    primary: ResolvedProvider,
+    fallbacks: list[ResolvedProvider],
+    system_prompt: str,
+    history: list[Turn],
+    user_text: str,
+    chat_id: int,
+) -> str:
+```
+
+  - **AC-1 short-circuit**: if `fallbacks == []`, return `await reply(primary, ...)` directly. No try/except, no AllProvidersFailed wrapping. The empty-fallback path is byte-for-byte identical to v0.1.3.
+  - Otherwise iterates `[primary, *fallbacks]`.
+  - Wraps each call in try/except.
+  - On success: returns immediately.
+  - On exception: log INFO with `from-provider/model -> next-provider/model: ExceptionClassName`. NO str(exc) — secret-leak hygiene. Continue.
+  - On exhaustion: raise `AllProvidersFailed(attempts=...)` where `attempts: list[tuple[provider_name, model_id, ExceptionClassName_str]]`. Log CRITICAL with the chain summary `provider1/model1: Class1; provider2/model2: Class2; ...` BEFORE raising. The original exceptions are preserved in `attempts` for debugging via `__cause__` chaining; CRITICAL log line carries class names only.
+
+- Tests T1-T7 from spec + applied fixes, in tests/test_l2_runtime.py:
+  - T1 primary succeeds → no fallback consulted (use AsyncMock to assert).
+  - T2 primary raises → first fallback called, returns its reply.
+  - T3 primary + first fallback raise → second fallback called.
+  - T4 all raise → AllProvidersFailed raised, attempts populated correctly, CRITICAL log present.
+  - T5 log content asserts (provider, model, error class on each step). Specifically: assert that str(exc) does NOT appear in the log lines.
+  - T6 (NEW from P1 fix) empty fallback list + primary raises → reply()'s exception bubbles up as-is, no AllProvidersFailed, no "having trouble" message synthesis.
+  - T7 (NEW) AllProvidersFailed exposes attempts list with provider, model, exception class name for each attempt.
+
+### Step 4 — Connector wiring
+
+Files: `agent/connectors/telegram.py`
+LOC budget: ~25
+
+- The `run()` signature gains `fallbacks: list[ResolvedProvider]` parameter.
+- In the message-handling path, replace the direct `await reply(provider, ...)` with `await reply_with_fallback(provider, fallbacks, ...)`.
+- On `AllProvidersFailed` exception: send the user-visible message "Having trouble reaching the LLM right now, please try again in a minute." Do not re-raise to PTB (suppress, like the existing error path does for misc exceptions).
+
+### Step 5 — Wire `fallbacks` through `__main__.connector_run()`
+
+Files: `agent/__main__.py`, `agent/connectors/telegram.py`
+LOC budget: ~10
+
+- `connector_run(config, resolve, memory, fallbacks)` instead of `connector_run(config, resolve, memory)`.
+- In `__main__.main()`, pass the resolved fallback list.
+
+### Step 6 — Config fixture tests
+
+Files: `tests/test_l1_config_registry.py`
+LOC budget: ~50 (4 tests)
+
+- T-cfg-1 empty/missing `fallback` loads cleanly.
+- T-cfg-2 non-list `fallback` raises ValidationError.
+- T-cfg-3 fallback referencing unknown provider raises ConfigError at resolve time. (Tested in test_l5_container.py since resolve happens in __main__.)
+- T-cfg-4 fallback referencing disallowed model raises ConfigError. Same.
+- T-cfg-5 (NEW from P2 cycle fix) fallback list contains an entry equal to an agent's model → ConfigError naming the conflict.
+- T-cfg-6 (NEW from P2 dedupe fix) fallback list with internal duplicates → ConfigError naming the dupe.
+- T-cfg-7 (NEW from P2 cap fix) fallback list of length 6 → ConfigError mentioning the cap.
+
+### Step 7 — End-to-end smoke test (manual)
+
+Files: `config.test.yaml` (gitignored, edit only)
+LOC budget: 0 (manual)
+
+- Set primary to an obviously broken provider (bogus base_url).
+- Set fallback to OpenRouter (working).
+- Run docker compose -f docker-compose.test.yaml --env-file .env.test up.
+- Send a Telegram message.
+- Bot should reply via the fallback. Log should show the fallback INFO line.
+- Tear down.
+
+### Step 8 — Documentation
+
+Files: `README.md`, `config.example.yaml`, `CHANGELOG.md`
+LOC budget: ~30 (docs)
+
+- README: small new section under "Switching providers" titled "Fallback chain", showing the optional `fallback:` block in config.yaml.
+- config.example.yaml: a commented example `fallback:` block at the bottom.
+- CHANGELOG: 0.1.4 entry "Added: optional `fallback:` config field…"
+
+### Step 9 — Version bump
+
+Files: `pyproject.toml`, `agent/__about__.py`
+LOC budget: ~2
+
+- 0.1.3 → 0.1.4 in both files.
+
+## Total LOC estimate
+
+~237 effective LOC across runtime, config, tests, and docs. Within the 300-LOC step budget if we count the whole change as one logical step. If we hit the 600-LOC test-runner trigger, we run pytest. We will run pytest at the end of step 6 anyway.
+
+## Plan-eng-review findings (codex, applied 2026-05-08)
+
+[P1] AC-1 violation: with empty fallback, the new flow still routes through reply_with_fallback and translates failures into the new "Having trouble" user message, which is a behavior change vs v0.1.3.
+APPLIED FIX: in Step 3, reply_with_fallback short-circuits when `fallbacks == []`: it calls `await reply(primary, ...)` directly and lets the exception propagate. No AllProvidersFailed wrapping when there is nothing to fall back to. Step 4 connector code only emits the "Having trouble" message on AllProvidersFailed, which by definition only fires when fallbacks were configured AND all of them failed. Empty-fallback path is byte-for-byte identical to v0.1.3.
+
+[P2] Degenerate cycle: operator could put the primary's `<provider>/<model-id>` in the fallback list and waste cost retrying the same broken endpoint.
+APPLIED FIX: in Step 1 config validation, raise ConfigError if any fallback entry equals `agents.<group>.model` for any agent that uses it. Also raise if duplicates exist within the fallback list.
+
+[P2] Unbounded chain length: huge fallback lists could blow up per-request cost or hit rate-limits cumulatively.
+APPLIED FIX: in Step 1 config validation, cap fallback length at 5. Operator can override with `fallback_max_length: N` if they really need more, but the default cap is opinionated. ConfigError if exceeded without override.
+
+[P2] Secret leak risk in CRITICAL log on full failure: full exception str() can leak request bodies, including api keys or user content.
+APPLIED FIX: in Step 3 logging, the AllProvidersFailed CRITICAL log line only emits `provider/model: ExceptionClassName` per attempt. No `str(exc)` in the chain summary. The per-step INFO logs already do the same. Stack traces still go through the existing scrubbing logger via `exc_info=True` (the L0 secret scrubber strips known patterns).
+
+## Risk register
+
+R1. pydantic-ai's `agent.run()` exception model. The current `reply()` only raises bare `Exception` from inside the OpenAI SDK. We rely on this being a single catch-all. Mitigation: keep the `except Exception` broad, log `exc_info=True` so we never lose stack traces.
+
+R2. The user-visible "having trouble" message is an English string. Acceptable for v0.1.x (English-only). Internationalisation deferred.
+
+R3. Order matters. The fallback list is "primary, then fallbacks in order." Document this prominently in README and config.example.yaml comments.
+
+R4. Cost. Each fallback attempt is a billable LLM call. Document this in README ("if your primary fails, you pay for the next attempt"). No automatic limit beyond the chain length.
+
+R5. Connector signature change is a breaking internal API. No external consumers exist (telegram is the only connector). Safe.
+
+## Out of plan (will not change)
+
+- agent.runtime.reply() function unchanged. The new wrapper sits beside it. Easier to revert if needed.
+- agent.registry.resolve() unchanged. We reuse it.
+- agent.config.Config schema gains one optional field. Existing configs are forward-compatible.
+- Telegram allowlist code unchanged.
+- Memory layer unchanged. Fallback only affects the LLM call, not what gets persisted.
+
+## Verification gates (per CLAUDE.md SDLC)
+
+Before this plan goes to code:
+- [ ] /plan-eng-review on this file (mandatory)
+- [ ] Anson approval
+
+Before commit:
+- [ ] /codex-review on the staged diff
+- [ ] All unit tests pass
+- [ ] Smoke test E1 verified via the existing test harness
+
+Before merge:
+- [ ] PR opened, Anson self-merge
+
+After merge:
+- [ ] Tag v0.1.4
+- [ ] GitHub Release with the CHANGELOG body
+- [ ] kayaclaw-site hero badge bump
+- [ ] Daily ship post drafts to GDoc

--- a/docs/spec/SPEC-v0.1.4-fallback.md
+++ b/docs/spec/SPEC-v0.1.4-fallback.md
@@ -1,0 +1,111 @@
+# SPEC v0.1.4 — Provider/model fallback
+
+Status: draft, awaiting plan + eng review
+Trello: #40
+
+## Problem
+
+If the configured provider's call fails (HTTP error, timeout, network blip, rate limit, out-of-credit), the agent today returns nothing usable to the user. The single point of failure is one bad day at one provider.
+
+Operators need a way to declare a fallback chain so the bot keeps replying when the primary fails.
+
+## User-visible behavior
+
+1. Operator declares a list of fallback `<provider>/<model-id>` references in config.yaml.
+2. On a normal request, the agent tries the primary model (`agents.<group>.model`) first.
+3. If that call fails for any reason (any non-2xx, exception, timeout), the agent tries the next reference in the fallback list, in declared order.
+4. The agent keeps trying until one succeeds. The successful reply is sent to the user as if nothing had happened.
+5. Each fallback attempt logs at INFO with the failing reference, the next reference, and the error class. Successful failover logs at INFO. The bot reply text is unchanged (no "(via fallback)" banner).
+6. If every reference in the chain fails, the agent sends a single user-visible message: "Having trouble reaching the LLM right now, please try again in a minute." A CRITICAL log line records the full chain of failures.
+
+## Non-goals (explicit)
+
+- Provider-internal fallback (e.g. OpenRouter's `models` array). That belongs to a separate generic mechanism (Trello #49) and ships in a later release.
+- Same-provider retry before switching. v0.1.4 goes straight to the next provider on first failure.
+- Cost-aware routing (cheapest first). Not in scope.
+- Detection of specific error classes (rate-limit-only fallback, etc.). All failures trigger fallback uniformly.
+- Per-agent fallback chains. v0.1.4 has one global chain in config.yaml.
+- Async / concurrent attempts. v0.1.4 is sequential.
+
+## Configuration
+
+Single new top-level field in config.yaml: `fallback`. List of `<provider>/<model-id>` strings.
+
+```yaml
+providers:
+  openrouter:
+    kind: openai_compatible
+    base_url: https://openrouter.ai/api/v1
+    api_key_env: OPENROUTER_API_KEY
+    allowed_models:
+      - meta-llama/llama-3.3-70b-instruct
+  groq:
+    kind: openai_compatible
+    base_url: https://api.groq.com/openai/v1
+    api_key_env: GROQ_API_KEY
+    allowed_models:
+      - llama-3.3-70b-versatile
+
+agents:
+  personal-assistant:
+    model: openrouter/meta-llama/llama-3.3-70b-instruct
+    system_prompt: "You are a helpful assistant."
+    connectors:
+      - telegram
+
+# Optional. If omitted or empty, behaviour is unchanged from 0.1.3.
+fallback:
+  - groq/llama-3.3-70b-versatile
+```
+
+Each entry in `fallback` must:
+- Be the form `<provider>/<model-id>` with both parts non-empty.
+- Reference a provider that exists in `providers`.
+- Reference a model the provider's `allowed_models` permits (subject to the existing wildcard rule).
+- The provider's `api_key_env` must be set in the environment at startup (validated by the existing v0.1.3 startup-key check, no new code).
+
+If any entry fails validation at startup, the agent exits with a clear ConfigError naming the offending entry. (Same pattern as the v0.1.3 startup validation.)
+
+## Acceptance criteria
+
+AC-1. With `fallback` empty or absent, behavior matches 0.1.3 byte-for-byte. No regression in existing tests.
+
+AC-2. With a single fallback entry, when the primary call raises any exception, the next entry is tried. The user receives the second provider's reply. A log line at INFO records the swap.
+
+AC-3. With multiple fallback entries, the agent tries them in declared order and stops on the first success.
+
+AC-4. When all entries fail, the user receives the configured "having trouble" message and the agent logs a CRITICAL line summarising the full chain.
+
+AC-5. Validation errors at startup (unknown provider in fallback, disallowed model, missing api_key_env) cause exit code 1 with a ConfigError naming the offending entry. No tool ever runs against a misconfigured fallback chain.
+
+AC-6. The fallback list is not iterated for failures unrelated to the LLM call (e.g., Telegram delivery error, allowlist rejection). Fallback only applies to the model.request() call.
+
+## Test plan
+
+Unit tests (`tests/test_l2_runtime.py` extension):
+- T1. Primary succeeds → no fallback consulted.
+- T2. Primary raises → first fallback called, succeeds → user sees its reply.
+- T3. Primary + first fallback both raise → second fallback called.
+- T4. All references raise → user-visible "having trouble" message and CRITICAL log.
+- T5. Logs name the failing reference, the next reference, and a one-line summary on full failure.
+
+Unit tests (`tests/test_l1_config_registry.py` extension):
+- T6. Empty/missing `fallback` field loads cleanly.
+- T7. Non-list `fallback` raises ConfigError.
+- T8. Fallback entry referencing unknown provider raises ConfigError.
+- T9. Fallback entry referencing disallowed model raises ConfigError.
+
+End-to-end via Telegram smoke test (existing harness):
+- E1. Configure primary as a deliberately broken provider (bogus base_url) + valid fallback. Send a message. Bot replies via fallback. Logs show the failover.
+
+## Out of scope (carry to backlog)
+
+- Provider-internal `models` array support (Trello #49)
+- Balance/credits aware routing (Trello #41)
+- Per-agent fallback chains
+- Fallback observability metrics
+
+## Open questions
+
+- Does pydantic-ai's Agent expose a clean error path so we can catch model.request failures without unwrapping internal exceptions?  (Plan-stage investigation.)
+- Does fallback need to thread through tool-calling responses, or only first-turn replies?  v0.1.x is reply-only, so first-turn reply only is fine. Lock to "first-turn reply" for v0.1.4.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "kayaclaw"
-version = "0.1.3"
+version = "0.1.4"
 description = "A small, hardened AI agent for Telegram. SQLite memory, your choice of OpenAI-compatible LLM provider."
 # `readme` field intentionally omitted in L0. README.md is created in L6.
 # Add `readme = "README.md"` here as part of L6 release polish.

--- a/tests/test_l1_config_registry.py
+++ b/tests/test_l1_config_registry.py
@@ -266,6 +266,78 @@ def test_resolve_anthropic_with_key_still_raises_not_implemented(monkeypatch):
     assert "0.1" in err
 
 
+# ---------------------------------------------------------------------------
+# v0.1.4 — fallback config validation
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_missing_loads_clean():
+    """T-cfg-1: missing fallback key → defaults to []."""
+    raw = _make_raw()
+    config = _load_from_dict(raw)
+    assert config.fallback == []
+
+
+def test_fallback_empty_list_loads_clean():
+    """T-cfg-1: explicit empty list → []."""
+    raw = _make_raw()
+    raw["fallback"] = []
+    config = _load_from_dict(raw)
+    assert config.fallback == []
+
+
+def test_fallback_non_list_raises_config_error():
+    """T-cfg-2: fallback as a string (not a list) → ConfigError."""
+    raw = _make_raw()
+    raw["fallback"] = "p/some-model"
+    with pytest.raises(ConfigError):
+        _load_from_dict(raw)
+
+
+def test_fallback_entry_without_slash_raises_config_error():
+    """T-cfg-2b: fallback entry missing '/' → ConfigError."""
+    raw = _make_raw()
+    raw["fallback"] = ["nosashstring"]
+    with pytest.raises(ConfigError):
+        _load_from_dict(raw)
+
+
+def test_fallback_entry_equals_agent_model_raises_config_error():
+    """T-cfg-5: fallback entry duplicates an agent's primary model → ConfigError."""
+    raw = _make_raw()
+    raw["fallback"] = ["example/some-model"]  # matches _VALID_AGENT.model
+    with pytest.raises(ConfigError) as exc_info:
+        _load_from_dict(raw)
+    assert "example/some-model" in str(exc_info.value)
+
+
+def test_fallback_internal_duplicates_raise_config_error():
+    """T-cfg-6: duplicates within fallback list → ConfigError naming the dupe."""
+    raw = _make_raw()
+    raw["fallback"] = ["groq/x", "groq/x"]
+    with pytest.raises(ConfigError) as exc_info:
+        _load_from_dict(raw)
+    assert "groq/x" in str(exc_info.value)
+
+
+def test_fallback_length_cap_exceeded_raises_config_error():
+    """T-cfg-7: fallback list of 6 entries → ConfigError mentioning the cap."""
+    raw = _make_raw()
+    raw["fallback"] = [f"p{i}/m{i}" for i in range(6)]
+    with pytest.raises(ConfigError) as exc_info:
+        _load_from_dict(raw)
+    err = str(exc_info.value)
+    assert "5" in err or "cap" in err.lower()
+
+
+def test_fallback_under_cap_loads_cleanly():
+    """5 distinct entries (the cap) loads cleanly."""
+    raw = _make_raw()
+    raw["fallback"] = [f"p{i}/m{i}" for i in range(5)]
+    config = _load_from_dict(raw)
+    assert len(config.fallback) == 5
+
+
 def test_resolve_config_error_messages_are_nonempty(monkeypatch):
     """ConfigError messages are non-empty human-readable strings in all failure cases."""
     config = load_config(_EXAMPLE_CONFIG)

--- a/tests/test_l2_runtime.py
+++ b/tests/test_l2_runtime.py
@@ -315,3 +315,231 @@ class TestReply:
         assert match is None, (
             f"Found Anthropic import in agent/runtime.py: {match.group()!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Step 3 (v0.1.4) — reply_with_fallback() tests
+# ---------------------------------------------------------------------------
+
+def _named_provider(provider_name: str, model_id: str = "m") -> ResolvedProvider:
+    return ResolvedProvider(
+        provider_name=provider_name,
+        kind="openai_compatible",
+        base_url="https://api.example.com/v1",
+        api_key="k",
+        model_id=model_id,
+    )
+
+
+class _Counter:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+
+def _make_reply_stub(behaviors: dict[str, object], counter: _Counter):
+    """behaviors: provider_name -> reply text (str) or Exception instance/class to raise."""
+
+    async def fake_reply(provider, system_prompt, history, user_text, chat_id):
+        counter.calls.append(provider.provider_name)
+        outcome = behaviors[provider.provider_name]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        if isinstance(outcome, type) and issubclass(outcome, BaseException):
+            raise outcome("simulated failure")
+        return outcome
+
+    return fake_reply
+
+
+class TestReplyWithFallback:
+    @pytest.mark.anyio
+    async def test_t1_primary_succeeds_no_fallback_consulted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agent import runtime as rt
+
+        counter = _Counter()
+        monkeypatch.setattr(
+            rt, "reply", _make_reply_stub({"primary": "ok"}, counter)
+        )
+        primary = _named_provider("primary")
+        fallbacks = [_named_provider("fb1"), _named_provider("fb2")]
+        result = await rt.reply_with_fallback(primary, fallbacks, "sys", [], "hi", chat_id=1)
+        assert result == "ok"
+        assert counter.calls == ["primary"]
+
+    @pytest.mark.anyio
+    async def test_t2_primary_fails_first_fallback_returns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agent import runtime as rt
+
+        counter = _Counter()
+        monkeypatch.setattr(
+            rt,
+            "reply",
+            _make_reply_stub(
+                {"primary": RuntimeError("boom"), "fb1": "fb1-reply", "fb2": "unused"},
+                counter,
+            ),
+        )
+        primary = _named_provider("primary")
+        fallbacks = [_named_provider("fb1"), _named_provider("fb2")]
+        result = await rt.reply_with_fallback(primary, fallbacks, "sys", [], "hi", chat_id=1)
+        assert result == "fb1-reply"
+        assert counter.calls == ["primary", "fb1"]
+
+    @pytest.mark.anyio
+    async def test_t3_primary_and_first_fallback_fail_second_used(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agent import runtime as rt
+
+        counter = _Counter()
+        monkeypatch.setattr(
+            rt,
+            "reply",
+            _make_reply_stub(
+                {
+                    "primary": RuntimeError("p"),
+                    "fb1": ValueError("v"),
+                    "fb2": "fb2-reply",
+                },
+                counter,
+            ),
+        )
+        primary = _named_provider("primary")
+        fallbacks = [_named_provider("fb1"), _named_provider("fb2")]
+        result = await rt.reply_with_fallback(primary, fallbacks, "sys", [], "hi", chat_id=1)
+        assert result == "fb2-reply"
+        assert counter.calls == ["primary", "fb1", "fb2"]
+
+    @pytest.mark.anyio
+    async def test_t4_all_fail_raises_all_providers_failed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from agent import runtime as rt
+
+        counter = _Counter()
+        monkeypatch.setattr(
+            rt,
+            "reply",
+            _make_reply_stub(
+                {
+                    "primary": RuntimeError("p"),
+                    "fb1": ValueError("v"),
+                    "fb2": KeyError("k"),
+                },
+                counter,
+            ),
+        )
+        primary = _named_provider("primary", "m1")
+        fallbacks = [_named_provider("fb1", "m2"), _named_provider("fb2", "m3")]
+
+        with caplog.at_level(logging.CRITICAL, logger="agent.runtime"):
+            with pytest.raises(rt.AllProvidersFailed) as exc_info:
+                await rt.reply_with_fallback(primary, fallbacks, "sys", [], "hi", chat_id=1)
+
+        assert counter.calls == ["primary", "fb1", "fb2"]
+        attempts = exc_info.value.attempts
+        assert attempts == [
+            ("primary", "m1", "RuntimeError"),
+            ("fb1", "m2", "ValueError"),
+            ("fb2", "m3", "KeyError"),
+        ]
+        critical_msgs = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.CRITICAL
+        ]
+        assert any("primary/m1: RuntimeError" in m for m in critical_msgs)
+        assert any("fb2/m3: KeyError" in m for m in critical_msgs)
+
+    @pytest.mark.anyio
+    async def test_t5_logs_do_not_leak_exception_str(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from agent import runtime as rt
+
+        counter = _Counter()
+        secret_blob = "SUPER-SECRET-REQUEST-BODY-12345"
+        monkeypatch.setattr(
+            rt,
+            "reply",
+            _make_reply_stub(
+                {
+                    "primary": RuntimeError(secret_blob),
+                    "fb1": ValueError(secret_blob),
+                },
+                counter,
+            ),
+        )
+        primary = _named_provider("primary")
+        fallbacks = [_named_provider("fb1")]
+
+        with caplog.at_level(logging.INFO, logger="agent.runtime"):
+            with pytest.raises(rt.AllProvidersFailed):
+                await rt.reply_with_fallback(primary, fallbacks, "sys", [], "hi", chat_id=1)
+
+        for record in caplog.records:
+            # Skip the underlying reply()'s exc_info traceback (it's the SDK
+            # path's responsibility, scrubbed by the L0 logger). We assert
+            # the wrapper's own log lines (INFO fallback + CRITICAL summary)
+            # contain only class names, never str(exc).
+            if record.name != "agent.runtime":
+                continue
+            if record.exc_info:
+                continue
+            assert secret_blob not in record.getMessage(), (
+                f"Exception str leaked into log: {record.getMessage()!r}"
+            )
+
+    @pytest.mark.anyio
+    async def test_t6_empty_fallback_passes_through_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC-1: empty fallback list → reply()'s exception bubbles, no AllProvidersFailed."""
+        from agent import runtime as rt
+
+        counter = _Counter()
+        monkeypatch.setattr(
+            rt,
+            "reply",
+            _make_reply_stub({"primary": RuntimeError("boom")}, counter),
+        )
+        primary = _named_provider("primary")
+        with pytest.raises(RuntimeError, match="boom"):
+            await rt.reply_with_fallback(primary, [], "sys", [], "hi", chat_id=1)
+        assert counter.calls == ["primary"]
+
+    @pytest.mark.anyio
+    async def test_t6b_empty_fallback_happy_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC-1: empty fallback list + primary success → returns primary's reply."""
+        from agent import runtime as rt
+
+        counter = _Counter()
+        monkeypatch.setattr(
+            rt, "reply", _make_reply_stub({"primary": "ok"}, counter)
+        )
+        primary = _named_provider("primary")
+        result = await rt.reply_with_fallback(primary, [], "sys", [], "hi", chat_id=1)
+        assert result == "ok"
+        assert counter.calls == ["primary"]
+
+    def test_t7_all_providers_failed_attempts_shape(self) -> None:
+        from agent.runtime import AllProvidersFailed
+
+        attempts = [
+            ("openrouter", "model-a", "RuntimeError"),
+            ("groq", "model-b", "TimeoutError"),
+        ]
+        exc = AllProvidersFailed(attempts)
+        assert exc.attempts == attempts
+        msg = str(exc)
+        assert "2 provider(s) failed" in msg
+        assert "openrouter/model-a: RuntimeError" in msg
+        assert "groq/model-b: TimeoutError" in msg

--- a/tests/test_l4_telegram.py
+++ b/tests/test_l4_telegram.py
@@ -392,6 +392,62 @@ class TestHandlerTokenScrubbing:
                 alog._SECRETS.remove(token)
 
 
+class TestHandlerAllProvidersFailed:
+    """v0.1.4: when reply_with_fallback raises AllProvidersFailed, the handler
+    must (1) send the fixed user-visible status message, (2) NOT persist an
+    assistant turn (memory must reflect what the user saw, and the user did
+    not see a real reply), and (3) emit the connector's exhaustion INFO line."""
+
+    pytestmark = pytest.mark.anyio
+
+    async def test_all_providers_failed_replies_status_no_assistant_persist(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from agent.runtime import AllProvidersFailed
+
+        memory = MagicMock()
+        memory.history.return_value = []
+
+        async def raises(*_args, **_kwargs):
+            raise AllProvidersFailed(
+                [
+                    ("primary", "m1", "RuntimeError"),
+                    ("fb1", "m2", "TimeoutError"),
+                ]
+            )
+
+        monkeypatch.setattr(tg.runtime, "reply_with_fallback", raises)
+
+        fallbacks = [_make_resolved(name="fb1", model="m2")]
+        handler = _make_handler(
+            {42}, _make_resolved(), "sp", memory, fallbacks=fallbacks
+        )
+        update = _make_update(chat_id=42, text="hello")
+
+        with caplog.at_level(logging.INFO, logger="agent.connectors.telegram"):
+            await handler(update, MagicMock())  # must not raise
+
+        # User turn persisted; assistant turn must NOT be persisted (the user
+        # did not receive a real reply, only a status line).
+        assert memory.append.call_count == 1
+        assert memory.append.call_args.args == (42, "user", "hello")
+
+        # The fixed user-visible status message went out exactly once.
+        update.effective_message.reply_text.assert_awaited_once_with(
+            "Having trouble reaching the LLM right now, "
+            "please try again in a minute."
+        )
+
+        # Connector emitted the exhaustion INFO line for ops visibility.
+        assert any(
+            "reply-fallback-exhausted" in r.getMessage()
+            and "chat_id=42" in r.getMessage()
+            for r in caplog.records
+        )
+
+
 class TestRunStartupLogging:
     """run() startup line emits provider/model + allowlist size only — no token."""
 

--- a/tests/test_l5_container.py
+++ b/tests/test_l5_container.py
@@ -184,8 +184,10 @@ class TestMainSyncContract:
         assert rc == 0
         connector_mock.assert_called_once()
         args = connector_mock.call_args.args
-        assert len(args) == 3, f"expected (config, resolve, memory); got {args!r}"
-        # arg[0] is the loaded Config; arg[1] is the resolve callable; arg[2] is Memory
+        assert len(args) == 4, (
+            f"expected (config, resolve, memory, fallbacks); got {args!r}"
+        )
+        # arg[0]: Config; arg[1]: resolve callable; arg[2]: Memory; arg[3]: fallback list
         from agent.config import Config
         from agent.memory import Memory
         from agent.registry import resolve as resolve_fn
@@ -193,6 +195,7 @@ class TestMainSyncContract:
         assert isinstance(args[0], Config)
         assert args[1] is resolve_fn
         assert isinstance(args[2], Memory)
+        assert args[3] == []  # default fixture has no fallback configured
 
 
 class TestMainKeyboardInterrupt:


### PR DESCRIPTION
## Summary
- Optional `fallback:` config field. List up to 5 `<provider>/<model-id>` alternates tried in order when the primary call fails. Empty or omitted keeps prior behaviour.
- Validation rejects length > 5, duplicates, and entries that equal an agent's primary model. Catches misconfigurations at config load, not at first user message.
- On full exhaustion the bot replies once with a fixed status message and logs the failure summary at CRITICAL with class names only. No exception bodies, no secrets.

## Test plan
- [x] Unit tests for the fallback runtime path (primary success, single failover, double failover, total exhaustion, log hygiene, empty-fallback passthrough, attempts shape).
- [x] Unit tests for config validation (missing/empty, non-list, missing slash, primary-model cycle, internal duplicates, length cap, valid 5-entry list).
- [x] Connector handler test for the exhaustion path's user-visible message + INFO log line.
- [x] Verified end-to-end against a live OpenAI-compatible provider for both the fallback-success and total-failure paths.

Closes #40