### PR TITLE
v0.1.8: provider-error clarity in init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to kayaclaw are documented in this file. Format follows Keep a Changelog (https://keepachangelog.com/en/1.1.0/). This project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8] - 2026-05-20
+
+### Changed
+- When init's provider key or Telegram token validation fails, the error message now shows the actual HTTP status, the endpoint hit, and the first chunk of the provider's response body so you can see exactly why it failed and copy-paste the text if you need to ask for help. A short menu lets you retry with the same value (after you fixed the upstream issue), paste a new value, or quit. There is no built-in retry cap any more: keep going until it works or quit. Secret values in the response body are redacted before display.
+
 ## [0.1.7] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ python3 -m agent init
 
 Each answer is validated against the real provider before init moves on.
 
+If validation fails (your key was bad, your account has no credit, the provider is rate-limiting you, anything), init now shows the upstream error verbatim and offers to retry once you have fixed the issue, without making you restart the whole setup.
+
 Bring it up:
 
 ```

--- a/agent/init/cli.py
+++ b/agent/init/cli.py
@@ -20,7 +20,73 @@ from agent.init.validators import (
 )
 from agent.init.writers import render_config, render_env, write_files
 
-_MAX_ATTEMPTS = 3
+# Status-to-headline mappers. Keyed by HTTP status code; the string
+# "network" is the sentinel for URLError / DNS / connection-refused, and
+# "5xx" / "other" are buckets the renderer falls back to. The renderer
+# follows the headline with a one-line HTTP context and an indented body
+# snippet (if present) so the user can copy-paste upstream errors when
+# asking for help.
+_PROVIDER_HEADLINES: dict[int | str, str] = {
+    401: "Provider rejected the key. Double-check it was copied correctly (no extra spaces).",
+    402: "Your provider account has no usage credit. Top up and retry.",
+    403: "Provider refused this key. The account may be suspended or the key lacks permission for /models.",
+    404: "Provider returned 404 on /models. Likely causes: wrong base_url, or the key has restricted endpoints (issue a new key with all endpoints enabled).",
+    429: "Provider is rate-limiting the key. Wait a minute and retry.",
+    "5xx": "Provider responded with a server error. Wait a moment and retry; if it persists, check the provider's status page.",
+    "network": "Could not reach the provider. Check your network and DNS.",
+    "other": "Provider returned an unexpected response.",
+}
+
+_TELEGRAM_HEADLINES: dict[int | str, str] = {
+    401: "Telegram rejected the token. Check it was copied correctly from BotFather.",
+    404: "Telegram rejected the token. Check it was copied correctly from BotFather.",
+    429: "Telegram is rate-limiting this bot. Wait a minute and retry.",
+    "5xx": "Telegram returned a server error. Retry in a moment.",
+    "network": "Could not reach api.telegram.org. Check your network.",
+    "other": "Telegram returned an unexpected response.",
+}
+
+
+def _headline_for(status_code: int | None, headlines: dict[int | str, str]) -> str:
+    """Pick the right headline for a given status. None means network failure."""
+    if status_code is None:
+        return headlines["network"]
+    if status_code in headlines:
+        return headlines[status_code]
+    if 500 <= status_code < 600:
+        return headlines["5xx"]
+    return headlines["other"]
+
+
+def _render_diagnostics(
+    result: ValidationResult,
+    headlines: dict[int | str, str],
+    *,
+    attempt: int | None = None,
+) -> None:
+    """Print structured diagnostics for a failed ValidationResult.
+
+    Layout:
+        <headline>
+        HTTP <status> from <endpoint>   (or "Network failure" if status_code is None)
+            <body snippet line 1>
+            <body snippet line 2>
+        (attempt N)   <- only if attempt is provided
+    """
+    headline = _headline_for(result.status_code, headlines)
+    print(f"  {headline}")
+    if result.status_code is None:
+        if result.endpoint:
+            print(f"  Network failure reaching {result.endpoint}")
+        else:
+            print("  Network failure")
+    else:
+        print(f"  HTTP {result.status_code} from {result.endpoint or '<unknown>'}")
+    if result.body_snippet:
+        for line in result.body_snippet.splitlines() or [result.body_snippet]:
+            print(f"      {line}")
+    if attempt is not None:
+        print(f"  (attempt {attempt})")
 
 # Mirrors config.example.yaml; drift between the two is enforced by tests.
 # `prefix_label` is set on providers whose API key has a published prefix
@@ -111,28 +177,58 @@ def _prompt_custom_provider() -> tuple[str, dict[str, str]]:
     }
 
 
+def _retry_menu() -> str:
+    """Show the post-failure menu and return one of 'r', 'n', or 'q'.
+
+    Default on bare Enter is 'r' so a user who fixed the upstream issue
+    and just hits Enter does the right thing. Unknown input reprompts.
+    """
+    while True:
+        raw = _prompt("  [r] retry with same value / [n] paste new value / [q] quit init: ").lower()
+        if raw == "" or raw == "r":
+            return "r"
+        if raw == "n":
+            return "n"
+        if raw == "q":
+            return "q"
+        print("  Please type r, n, or q.")
+
+
 def _retry_validator(
     prompt_text: str,
     validator: Callable[[str], ValidationResult],
-    failure_advice: str,
+    headlines: dict[int | str, str],
+    *,
     prompter: Callable[[str], str] = _prompt,
+    initial_value: str | None = None,
 ) -> tuple[str, ValidationResult]:
-    """Run validator up to _MAX_ATTEMPTS times. Returns (raw_value, result).
+    """Loop until the validator returns ok, or the user picks [q].
 
-    On all-attempts-failed, exits the process with code 1. Pass
-    `prompter=_prompt_secret` to hide the typed value (API keys, tokens).
+    On failure, renders structured diagnostics (headline + HTTP info +
+    indented body snippet) via `_render_diagnostics`, then shows the
+    [r]/[n]/[q] menu. `[r]` retries with the same value (user has fixed
+    the upstream issue). `[n]` re-prompts for a new value. `[q]` raises
+    KeyboardInterrupt, which `main()` catches and turns into a clean
+    exit. Ctrl-C is treated the same as `[q]`. No attempt cap.
+
+    `initial_value` short-circuits the first prompt (used by the
+    detected-prefix path in `_step_provider` so the user doesn't have
+    to retype a key they already pasted).
     """
-    for attempt in range(_MAX_ATTEMPTS):
-        value = prompter(prompt_text)
+    value = initial_value if initial_value is not None else prompter(prompt_text)
+    attempt = 1
+    while True:
         result = validator(value)
         if result.ok:
             return value, result
-        remaining = _MAX_ATTEMPTS - attempt - 1
-        print(f"  Error: {result.error}")
-        if remaining > 0:
-            print(f"  Please try again ({remaining} attempt(s) remaining).")
-    print(f"  {_MAX_ATTEMPTS} attempts failed. {failure_advice}")
-    sys.exit(1)
+        _render_diagnostics(result, headlines, attempt=attempt)
+        choice = _retry_menu()
+        if choice == "q":
+            raise KeyboardInterrupt
+        if choice == "n":
+            value = prompter(prompt_text)
+        # else 'r': value unchanged
+        attempt += 1
 
 
 def _step_provider() -> tuple[str, dict[str, str], str]:
@@ -148,11 +244,25 @@ def _step_provider() -> tuple[str, dict[str, str], str]:
             prefix_label = provider_cfg.get("prefix_label", provider_cfg["label"])
             article = "an" if prefix_label[:1].lower() in "aeiou" else "a"
             if _confirm(f"Looks like {article} {prefix_label} key. Proceed?"):
-                result = validate_provider_key(provider_cfg["base_url"], raw)
-                if result.ok:
+                # Route the detected-prefix path through the retry loop
+                # so it gets the same diagnostics and [r]/[n]/[q] menu
+                # as the picker path. Falling back to the picker now
+                # requires the user to pick [q] at the menu, not a
+                # silent error-and-fall-through.
+                def _val_detected(key: str) -> ValidationResult:
+                    return validate_provider_key(provider_cfg["base_url"], key)
+                try:
+                    api_key, _ = _retry_validator(
+                        f"Paste your {provider_cfg['label']} API key (not echoed): ",
+                        _val_detected,
+                        _PROVIDER_HEADLINES,
+                        prompter=_prompt_secret,
+                        initial_value=raw,
+                    )
                     print(f"  Provider key valid for {provider_cfg['label']}.")
-                    return detected, provider_cfg, raw
-                print(f"  Error: {result.error}")
+                    return detected, provider_cfg, api_key
+                except KeyboardInterrupt:
+                    print("  Switching to provider picker.")
         elif detected == "openai-suspect":
             print("  That looks like it might be an OpenAI key. OpenAI is not")
             print("  in the supported list. Pick your provider from the list:")
@@ -166,7 +276,7 @@ def _step_provider() -> tuple[str, dict[str, str], str]:
     api_key, _result = _retry_validator(
         f"Paste your {provider_cfg['label']} API key (not echoed): ",
         _val,
-        "Check the provider's API key dashboard.",
+        _PROVIDER_HEADLINES,
         prompter=_prompt_secret,
     )
     print(f"  Provider key valid for {provider_cfg['label']}.")
@@ -181,7 +291,7 @@ def _step_telegram_token() -> tuple[str, str]:
     token, result = _retry_validator(
         "Paste your Telegram bot token (not echoed): ",
         validate_telegram_token,
-        "Check the token from @BotFather on Telegram.",
+        _TELEGRAM_HEADLINES,
         prompter=_prompt_secret,
     )
     bot_username = (result.data or {}).get("username", "")
@@ -301,10 +411,18 @@ def main() -> int:
     print("kayaclaw init")
     print("Walk through four questions to set up your first install.")
     _check_docker_presence()
-    if not _step_existing_files():
+    try:
+        if not _step_existing_files():
+            return 0
+        provider_key, provider_cfg, api_key = _step_provider()
+        token, bot_username = _step_telegram_token()
+        chat_id = _step_chat_id(token, bot_username)
+        _step_write(token, chat_id, provider_cfg, api_key, provider_key)
         return 0
-    provider_key, provider_cfg, api_key = _step_provider()
-    token, bot_username = _step_telegram_token()
-    chat_id = _step_chat_id(token, bot_username)
-    _step_write(token, chat_id, provider_cfg, api_key, provider_key)
-    return 0
+    except KeyboardInterrupt:
+        # [q] in the retry menu raises this, as does an actual Ctrl-C.
+        # No partial files have been written: _step_write is the only
+        # writer and it runs last.
+        print()
+        print("Setup aborted. Nothing was written.")
+        return 1

--- a/agent/init/validators.py
+++ b/agent/init/validators.py
@@ -5,7 +5,11 @@ ValidationResult so cli.py can drive retry loops without HTTP details
 leaking into the flow.
 
 Uses urllib.request rather than httpx to avoid dragging in pydantic-ai
-and the OpenAI SDK at init cold-start time (see ADR-1 in the plan).
+and the OpenAI SDK at init cold-start time (see ADR-1 in the L7 plan).
+
+Each ValidationResult carries `status_code`, `endpoint`, and
+`body_snippet` so the CLI can render actionable diagnostics and offer
+retry-after-fix without re-prompting.
 """
 from __future__ import annotations
 
@@ -17,33 +21,98 @@ from typing import NamedTuple
 
 _HTTP_TIMEOUT_SECONDS = 10
 
+# Cap on diagnostic snippets shown back to the user. Large enough to
+# carry full provider error chains (URL paths, error codes), small enough
+# that a hostile or misconfigured upstream can't flood the terminal.
+BODY_SNIPPET_MAX_CHARS = 500
+# Hard cap on the body actually read from the socket. 4x the snippet
+# cap covers UTF-8 multibyte expansion and gives a small buffer for
+# JSON parsing without ever buffering megabytes from a broken upstream.
+_BODY_READ_LIMIT = BODY_SNIPPET_MAX_CHARS * 4
+
 
 class ValidationResult(NamedTuple):
     ok: bool
     error: str | None
     data: dict | None
+    # status_code is None for network-level failures (DNS, connection
+    # refused, timeout) and for local-input rejections (empty token).
+    status_code: int | None = None
+    endpoint: str | None = None
+    body_snippet: str | None = None
 
 
-def _get_json(url: str, headers: dict[str, str] | None = None) -> tuple[int, dict]:
-    """GET url, parse JSON body. Returns (status_code, parsed_dict).
+# Generic regexes for well-known key shapes. The per-call `also_redact`
+# list catches the user's actual pasted value verbatim: keys without a
+# published prefix (e.g. DeepInfra's 32-char alphanumeric) won't match
+# anything here on their own.
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}"),
+    re.compile(r"\bgsk_[A-Za-z0-9]{20,}"),
+    re.compile(r"\bxox[abp]-[A-Za-z0-9\-]{10,}"),
+    re.compile(r"\b\d{8,11}:[A-Za-z0-9_\-]{30,}"),
+    re.compile(r"Bearer\s+[A-Za-z0-9._\-]{16,}", re.IGNORECASE),
+    re.compile(r"(?im)^[A-Z_]*(?:TOKEN|SECRET|API_KEY|PASSWORD)[A-Z_]*\s*=\s*\S+"),
+)
 
-    Raises urllib.error.URLError on network failure, json.JSONDecodeError
-    on malformed body. Non-2xx responses do NOT raise here; the caller
-    decides how to interpret 401/403/etc.
+_REDACTED = "[REDACTED]"
+
+
+def _scrub_secrets(text: str, *, also_redact: list[str] | None = None) -> str:
+    """Redact common secret patterns plus any caller-supplied literals.
+
+    Idempotent. Safe on empty/None-like inputs. Use `also_redact` to
+    redact the user's own pasted key, which generic patterns won't
+    catch when the provider uses a non-standard key shape.
+    """
+    if not text:
+        return ""
+    out = text
+    if also_redact:
+        for literal in also_redact:
+            # Only redact non-trivial literals: a 1-char "redact" would
+            # blanket the whole body. 8 chars is the floor for any real
+            # API key.
+            if literal and len(literal) >= 8:
+                out = re.sub(re.escape(literal), _REDACTED, out)
+    for pat in _SECRET_PATTERNS:
+        out = pat.sub(_REDACTED, out)
+    return out
+
+
+def _snippet(body: str, *, also_redact: list[str] | None = None) -> str:
+    """Truncate + scrub. Returns "" for empty input so the field stays
+    serialisable (consumers can treat None vs "" as "no body" either way)."""
+    if not body:
+        return ""
+    return _scrub_secrets(body[:BODY_SNIPPET_MAX_CHARS], also_redact=also_redact)
+
+
+def _get_json(
+    url: str, headers: dict[str, str] | None = None
+) -> tuple[int, dict, str]:
+    """GET url, parse JSON body. Returns (status_code, parsed_dict, raw_body).
+
+    Raises urllib.error.URLError on network failure. Non-2xx HTTP
+    responses do NOT raise: the body is captured for the caller to
+    interpret. Malformed JSON parses to an empty dict but the raw_body
+    is still returned so the caller can build a diagnostic snippet.
     """
     req = urllib.request.Request(url, headers=headers or {})
     try:
         with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:
             status = resp.status
-            body = resp.read().decode("utf-8")
+            body = resp.read(_BODY_READ_LIMIT).decode("utf-8", errors="replace")
     except urllib.error.HTTPError as e:
         status = e.code
-        body = e.read().decode("utf-8", errors="replace")
+        body = e.read(_BODY_READ_LIMIT).decode("utf-8", errors="replace")
     try:
         parsed = json.loads(body) if body else {}
+        if not isinstance(parsed, dict):
+            parsed = {}
     except json.JSONDecodeError:
         parsed = {}
-    return status, parsed
+    return status, parsed, body
 
 
 def validate_telegram_token(token: str) -> ValidationResult:
@@ -53,28 +122,54 @@ def validate_telegram_token(token: str) -> ValidationResult:
         return ValidationResult(False, "Token is empty.", None)
     url = f"https://api.telegram.org/bot{token}/getMe"
     try:
-        status, parsed = _get_json(url)
+        status, parsed, body = _get_json(url)
     except urllib.error.URLError as e:
         return ValidationResult(
             False,
             f"Could not reach api.telegram.org. Check your network. ({e.reason})",
             None,
+            status_code=None,
+            endpoint=url,
+            body_snippet=None,
         )
+    snippet = _snippet(body, also_redact=[token])
     if status == 200 and parsed.get("ok") is True:
         result = parsed.get("result") or {}
         username = result.get("username")
         if not username:
-            return ValidationResult(False, "Telegram returned no bot username.", None)
-        return ValidationResult(True, None, {"username": username})
+            return ValidationResult(
+                False,
+                "Telegram returned no bot username.",
+                None,
+                status_code=status,
+                endpoint=url,
+                body_snippet=snippet,
+            )
+        return ValidationResult(
+            True,
+            None,
+            {"username": username},
+            status_code=status,
+            endpoint=url,
+            body_snippet=snippet,
+        )
     if status in (401, 404):
         return ValidationResult(
-            False, "Telegram rejected the token. Check it was copied correctly.", None
+            False,
+            "Telegram rejected the token. Check it was copied correctly.",
+            None,
+            status_code=status,
+            endpoint=url,
+            body_snippet=snippet,
         )
     description = parsed.get("description") if isinstance(parsed, dict) else None
     return ValidationResult(
         False,
         f"Telegram returned HTTP {status}: {description or 'unexpected response'}",
         None,
+        status_code=status,
+        endpoint=url,
+        body_snippet=snippet,
     )
 
 
@@ -89,26 +184,43 @@ def validate_provider_key(base_url: str, api_key: str) -> ValidationResult:
     url = f"{base_url}/models"
     headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
     try:
-        status, parsed = _get_json(url, headers=headers)
+        status, _parsed, body = _get_json(url, headers=headers)
     except urllib.error.URLError as e:
         return ValidationResult(
             False,
             f"Could not reach {base_url}. Check your network. ({e.reason})",
             None,
+            status_code=None,
+            endpoint=url,
+            body_snippet=None,
         )
+    snippet = _snippet(body, also_redact=[api_key])
     if status == 200:
-        return ValidationResult(True, None, {"status": 200})
+        return ValidationResult(
+            True,
+            None,
+            {"status": 200},
+            status_code=status,
+            endpoint=url,
+            body_snippet=snippet,
+        )
     if status in (401, 403):
         return ValidationResult(
             False,
             f"Provider rejected the key (HTTP {status}). Check it was copied "
             f"correctly and the account has credit.",
             None,
+            status_code=status,
+            endpoint=url,
+            body_snippet=snippet,
         )
     return ValidationResult(
         False,
         f"Provider returned HTTP {status} from {url}. Unexpected response.",
         None,
+        status_code=status,
+        endpoint=url,
+        body_snippet=snippet,
     )
 
 

--- a/docs/impl/PLAN-v0.1.8-provider-errors.md
+++ b/docs/impl/PLAN-v0.1.8-provider-errors.md
@@ -1,0 +1,174 @@
+# PLAN: v0.1.8 : provider-error clarity in init
+
+**Status:** Draft (rev 2 : plan-eng-review applied)
+**Owner:** Anson
+**Author:** Hao (plan-writer)
+**Spec ref:** `docs/spec/SPEC-v0.1.8-provider-errors.md`
+**Date:** 2026-05-20
+**Branch:** `v0.1.8-provider-errors`
+
+## Revision log
+
+- **rev 2 (2026-05-20):** Applied all 7 findings from `/plan-eng-review`. P1s (A early-happy-path bypass, B scrubber-misses-custom-keys, C Telegram-branch-no-snippet) folded into Step 1 + Step 3. P2s (D explicit-retry-menu, E CLI-test-surface-note, F retry-attempt counter, G 500-char snippet) folded into Step 1 + Step 3 + test plan.
+- **rev 1 (2026-05-20):** Initial plan written from SPEC-v0.1.8-provider-errors.md.
+
+## 1. What's actually changing
+
+Three files, surgically:
+
+```
+agent/init/validators.py   ← extend ValidationResult with diagnostics; add secret scrubber
+agent/init/cli.py          ← status→headline mapper; render diagnostics block; retry-after-fix loop
+tests/test_l7_init_validators.py  ← extend existing tests + new tests for diagnostics + scrubber
+tests/test_l7_init_cli.py         ← new (or extended) tests for retry-after-fix + headline mapping
+CHANGELOG.md + pyproject.toml + README.md   ← release plumbing
+```
+
+Nothing else. No new packages. No new dependencies. No runtime changes outside the init flow.
+
+## 2. Data shape change
+
+Today:
+
+```python
+class ValidationResult(NamedTuple):
+    ok: bool
+    error: str | None
+    data: dict | None
+```
+
+After:
+
+```python
+class ValidationResult(NamedTuple):
+    ok: bool
+    error: str | None
+    data: dict | None
+    status_code: int | None = None      # HTTP status when applicable; None for network/local failures
+    endpoint: str | None = None         # URL that was hit
+    body_snippet: str | None = None     # first 200 chars of response body, secrets scrubbed
+```
+
+Defaults keep existing callers source-compatible. The init CLI is the only consumer; everything else just sees richer `ValidationResult`.
+
+## 3. Tiny steps
+
+Each step ≤300 LOC, ≤3 files. Standard SDLC gates apply: tests after each step.
+
+### Step 1: ValidationResult shape + validator wiring
+
+**Files:** `agent/init/validators.py`, `tests/test_l7_init_validators.py`
+
+- Extend `ValidationResult` with 3 optional fields (defaults `None`).
+- Both validators populate the new fields on every return path (success and failure).
+- Body snippet: first 200 chars of the raw response body, post-scrubber.
+- Add `_scrub_secrets(text: str) -> str` (private). Pattern set: `sk-[A-Za-z0-9_\-]{16,}`, `gsk_[A-Za-z0-9]{20,}`, `Bearer\s+\S{16,}`, `[A-Z_]*TOKEN[A-Z_]*\s*=\s*\S+`, `[A-Z_]*API_KEY[A-Z_]*\s*=\s*\S+`. Replace with `[REDACTED]`.
+- Existing tests get the new fields asserted where relevant. New tests:
+  - `body_snippet` is populated on failure for both validators.
+  - `body_snippet` is scrubbed (test with each pattern).
+  - `body_snippet` is capped at 500 chars (P2-G: 200 was arbitrary; some providers return useful info past 200 : full URL chains, error stacks).
+  - `status_code` and `endpoint` populated on success and on every failure branch.
+  - **P1-C:** Telegram 401/404 branch (today returns `None, None, None`) must now populate `status_code`, `endpoint`, and `body_snippet` from the parsed response body before returning.
+  - **P1-B:** `_scrub_secrets(text, *, also_redact: list[str] | None = None)` takes an optional list of literal strings to redact in addition to the generic regex set. Each validator passes the input key (`api_key` / `token`) via `also_redact=[input_key]` so providers that echo the request key in error bodies cannot leak it, even for custom key shapes (e.g., DeepInfra's 32-char alphanumeric, which the generic patterns do not match). The scrubber escapes the literal with `re.escape` before substituting.
+
+**Out:** richer ValidationResult, consumer-facing data shape locked.
+
+### Step 2: Status→headline mapper + diagnostics renderer in CLI
+
+**Files:** `agent/init/cli.py`, `tests/test_l7_init_cli.py` (new file)
+
+- Add two module-level dicts: `_PROVIDER_HEADLINES` and `_TELEGRAM_HEADLINES`, keyed by status code (and a `"network"` and `"other"` sentinel).
+- Add `_render_diagnostics(result: ValidationResult, headlines: dict) -> None`. Prints:
+  - One-line headline (mapped from status).
+  - One-line "HTTP {status} from {endpoint}" technical line.
+  - Indented body snippet block if present.
+- Keep print I/O in cli.py only. Validators stay pure.
+- Tests use `capsys` to assert the rendered text for each status.
+
+**Out:** when validator returns failure, cli renders structured diagnostics.
+
+### Step 3: Retry-after-fix loop + early-happy-path routing
+
+**Files:** `agent/init/cli.py`, `tests/test_l7_init_cli.py` (new), `tests/test_l7_init_integration.py` (extended)
+
+**Note on test surface (P2-E):** CLI logic today is only exercised via the integration test (no dedicated unit-test file). This step CREATES `tests/test_l7_init_cli.py` for focused CLI unit tests AND extends the integration test with a 404-then-retry-success scenario. Both surfaces matter: unit tests are cheap and pin the menu/headline behaviour; the integration test proves the full init flow still produces a working `.env` after a retry.
+
+- Replace `_retry_validator`'s 3-attempt cap with an unbounded loop that:
+  - First attempt: prompt for the value.
+  - On failure: render diagnostics (Step 2), then present an **explicit menu** (P2-D):
+    ```
+    [r] Retry with the same value (you fixed the upstream issue)
+    [n] Paste a new value
+    [q] Quit init
+    ```
+    Read a single-char response. Default on Enter = `r`. Unknown char reprompts the menu. (Reason: empty-input-means-retry combined with `getpass` lets a stray space silently change behaviour. The explicit menu makes intent unambiguous.)
+  - On `[r]`: re-validate the previously-stored value.
+  - On `[n]`: prompt again for a new value, then validate.
+  - On `[q]`: raise `KeyboardInterrupt` so the existing top-level Ctrl-C handling does the clean-exit (no partial files).
+  - Ctrl-C at any sub-prompt: same as `[q]`.
+- **Retry-attempt counter (P2-F):** track per-loop attempt count locally. Pass it into the diagnostics renderer so the final line can read `(attempt N)`. Counter is local-only : no telemetry, no file writes : but exists so v0.1.9 can wire it to "after 7 attempts, here's a doc link" without a second refactor.
+- **P1-A : early happy path:** `_step_provider()` (cli.py:140-160) detects a known-prefix key via `detect_provider_from_key` and inline-calls `validate_provider_key` once, printing `result.error` on failure before falling through to the picker. This bypasses the new diagnostics + retry-after-fix. Fix: route this path through `_retry_validator` too, by calling `_retry_validator` with a one-shot prompter that returns the already-pasted key on the first call and then delegates to `_prompt_secret` for any subsequent `[n]` selection. The picker fallback only fires if the user explicitly chooses `[q]` at the retry menu (the user already confirmed the detected provider; "give up and pick from the list" is now a separate explicit action, not silent fall-through).
+- Tests:
+  - Same-value retry after fix → second call succeeds (`[r]` then validator OK).
+  - New-value retry → `[n]` prompts and validator sees new input.
+  - Seven failures then success on the eighth : confirms no cap.
+  - `[q]` raises KeyboardInterrupt : confirms clean-exit path.
+  - Ctrl-C at retry prompt → KeyboardInterrupt propagates (existing behaviour).
+  - **P1-A regression:** detected-prefix-then-fail-then-retry-success : confirms the early-happy-path now respects the retry loop.
+  - Diagnostics renderer shows `(attempt N)` on the Nth failure.
+
+**Out:** users can iterate on upstream issues without restarting init, regardless of whether they took the detected-prefix path or the picker path.
+
+### Step 4: Release plumbing
+
+**Files:** `CHANGELOG.md`, `pyproject.toml`, `README.md`
+
+- CHANGELOG entry under `[0.1.8] - <release date>`, voice-rule compliant (no internal-tool names, no `[P1]/[P2]` tags, no em-dashes).
+- `pyproject.toml` version bump `0.1.7` → `0.1.8`.
+- README: one-paragraph note in the "If init fails" or troubleshooting section pointing out that the validator now retries without restarting and shows the upstream provider's error verbatim.
+
+**Out:** ready for tag + GitHub release.
+
+## 4. Test strategy
+
+- Per-step unit tests as above.
+- One integration test in `tests/test_l7_init_integration.py` (if it exists) or extended: a mocked-HTTP run-through of init that hits a 404 from the provider, prints the v0.1.8 guidance, retries on Enter with success, and writes the files.
+- No live network. urllib mocked at `agent.init.validators.urllib.request.urlopen` exactly as v0.1.7 tests do.
+
+## 5. Backwards-compat sanity
+
+- `ValidationResult` is a NamedTuple; adding optional fields with defaults preserves positional and keyword access for the existing 3 fields.
+- The CLI's call sites already use `result.ok`, `result.error`, `result.data` : no rename.
+- External callers of `agent.init.validators` outside the init CLI: none. The package is self-contained.
+
+## 6. Resolved open questions from spec §10
+
+- **Secret scrubber lives in `validators.py`** as `_scrub_secrets(text, *, also_redact)`. Inlined, no Mira dep, minimal pattern set, takes per-call literals so the user's own pasted key is always redacted (P1-B).
+- **No retry cap.** Removing the 3-attempt limit matches spec §4.1.6 and §AC4-5. Explicit `[r]/[n]/[q]` menu replaces empty-input-means-retry to avoid stray-space false retries (P2-D). Attempt counter tracked locally for future v0.1.9 surface (P2-F).
+- **Per-validator headline dicts** (not shared). They're 6-7 lines each, deduplication saves nothing and obscures intent.
+- **Early happy path (detected-prefix) routes through `_retry_validator` too.** (P1-A) Picker fallback is now an explicit `[q]` action, not silent fall-through.
+- **Body snippet capped at 500 chars** (not 200, P2-G). Still safe, more useful for providers with verbose error bodies.
+
+## 7. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Secret scrubber misses a pattern, leaks a key | Pattern set covers all formats kayaclaw has seen in v0.1.7 smokes; add patterns as new providers are added. |
+| User pastes a NEW wrong key on retry, thinks it's still the old one | Diagnostics line shows `HTTP {status} from {endpoint}` : same status on second try means same issue, different status means user changed something. Self-evident. |
+| Removing the 3-attempt cap encourages flailing | Spec §10 confirms decision. If real users complain, add a soft "you've retried 5 times, want to abort?" prompt in a future minor. |
+| `ValidationResult` shape change breaks an external consumer | grep confirms zero external consumers in this repo; v0.1.x has no published Python API contract. |
+| Body snippet shows internal API URL containing secret-like tokens | Scrubber runs before snippet is set, not before display. |
+
+## 8. Definition of done
+
+All 7 acceptance criteria from spec §8 met, full test suite green, manual smoke against a real OpenRouter restricted key (or its mock) confirms the v0.1.7 Wei dead-end is gone.
+
+## 9. SDLC gates (per CLAUDE.md and kayaclaw memory rules)
+
+1. `/plan-eng-review` on THIS plan, before any code. Apply P1 findings here.
+2. After each code step: tests must pass.
+3. After all code: `/simplify` on the staged diff (kayaclaw anti-bloat gate).
+4. Then `/codex-review` on the staged diff (mandatory pre-commit gate).
+5. Apply review findings (P1 before commit, P2/P3 in commit message or follow-up).
+6. Human smoke before final ship (Mira is deferred; Wei or Anson runs it).
+7. Per-piece approval for any public-facing copy (CHANGELOG entry, README addition, ship post).

--- a/docs/spec/SPEC-v0.1.8-provider-errors.md
+++ b/docs/spec/SPEC-v0.1.8-provider-errors.md
@@ -1,0 +1,128 @@
+# SPEC: v0.1.8 : provider-error clarity in init
+
+**Status:** Draft
+**Owner:** Anson
+**Author:** Hao (spec-writer)
+**Date:** 2026-05-20
+**Carries over from:** v0.1.7 init smoke (Wei) where Azentiq's OpenRouter key returned 404 due to account guardrails and init's "Unexpected response" message stranded the tester.
+
+## 1. Why this exists
+
+`python -m agent init` validates the provider API key against the OpenAI-compatible `/models` endpoint before writing config. Today, anything other than 200/401/403 returns a generic message:
+
+> Provider returned HTTP {status} from {url}. Unexpected response.
+
+That hides the actual cause from the user. Wei's smoke caught this: his key was technically valid but the OpenRouter account had account-level guardrails returning 404 on every endpoint. The init UX gave him no actionable next step. The fix took an unrelated DM ("create a new key with no guardrails") because the validator told him nothing useful.
+
+Real self-hosters will hit the same dead-end on: rate-limited keys (429), no-credit accounts (402), wrong base_url (404), suspended accounts (403 with body), partial outages (5xx), DNS issues (network). Each currently fails opaquely.
+
+## 2. Scope
+
+In-scope:
+- Better error surfacing on provider key validation failure.
+- Map common HTTP statuses to one-sentence actionable guidance.
+- Show the response body's first 200 chars (verbatim) so the user can copy-paste the upstream error if asking for help.
+- Retry-after-fix loop so the user can rerun the validator without restarting the whole init flow.
+- Apply the same treatment to Telegram token validation (parallel UX problem, smaller blast radius).
+
+Out-of-scope:
+- Auto-creating provider accounts.
+- Heuristic provider switching (e.g. "your DeepInfra key looks invalid, want to try OpenRouter?"). That's a v0.2.x conversation.
+- Changing the validator's transport (still urllib, no httpx).
+- Changes outside the `init` flow.
+
+## 3. Personas
+
+| Who | What they hit today | What they hit after v0.1.8 |
+|-----|---------------------|----------------------------|
+| First-time self-hoster with a no-credit OpenRouter key | "Unexpected response" | "Your account has no usage credit. Top it up at openrouter.ai/credits, then press Enter to retry." |
+| Self-hoster with account guardrails (Azentiq case) | "Unexpected response" | "Provider returned 404 on /models : your API key works but has restricted endpoints. Issue a new key with all endpoints enabled, then press Enter to retry." |
+| Self-hoster mistyped base_url | "Unexpected response" | "Provider returned 404 on /models : check the base_url is correct (commonly https://openrouter.ai/api/v1)." |
+| Self-hoster on a flaky network | "Could not reach ..." | Same as today, plus retry loop. |
+
+## 4. User scenarios
+
+### 4.1 Provider key validation fails
+
+1. User pastes their API key.
+2. Init posts to `{base_url}/models`.
+3. Validator returns a structured failure with: status code, endpoint, body snippet.
+4. Init renders:
+   - One-line headline mapped from status (see §5).
+   - Status code + endpoint hit (so the user can verify).
+   - First 200 chars of the response body, indented.
+   - "Press Enter to retry after you've fixed it, or Ctrl-C to abort."
+5. User fixes the underlying issue (tops up credit, re-issues key, etc).
+6. User presses Enter; init re-runs validation with the same input. No re-typing.
+7. On success, init moves on.
+
+### 4.2 Telegram token validation fails
+
+Same shape as §4.1 but for `api.telegram.org/bot<TOKEN>/getMe`. Statuses simpler (401/404 = bad token, 5xx = Telegram outage, network = local).
+
+### 4.3 User wants to start over
+
+Ctrl-C exits cleanly. No state written. Re-running `python -m agent init` starts from the top.
+
+## 5. Status-to-guidance mapping
+
+The validator returns the status; init renders a one-liner. Mapping (provider):
+
+| HTTP | Headline |
+|------|----------|
+| 401 | "Provider rejected the key. Double-check it was copied correctly (no extra spaces)." |
+| 402 | "Your provider account has no usage credit. Top up and retry." |
+| 403 | "Provider refused this key. The account may be suspended or the key lacks permission for /models." |
+| 404 | "Provider returned 404 on /models. Likely causes: wrong base_url, or the key has restricted endpoints (issue a new key with all endpoints enabled)." |
+| 429 | "Provider is rate-limiting the key. Wait a minute and retry." |
+| 5xx | "Provider responded with a server error. Wait a moment and retry; if it persists, check the provider's status page." |
+| network | "Could not reach {base_url}. Check your network and DNS." |
+| other | "Provider returned HTTP {status}. Body snippet below." |
+
+Mapping (Telegram):
+
+| HTTP | Headline |
+|------|----------|
+| 401, 404 | "Telegram rejected the token. Check it was copied correctly from BotFather." |
+| 429 | "Telegram is rate-limiting this bot. Wait a minute and retry." |
+| 5xx | "Telegram returned a server error. Retry in a moment." |
+| network | "Could not reach api.telegram.org. Check your network." |
+| other | "Telegram returned HTTP {status}. Body snippet below." |
+
+## 6. Functional requirements
+
+- F1. `validate_provider_key` returns enough information for the renderer to map a status: keep `ok`, `error`, and add `status_code: int | None`, `endpoint: str | None`, `body_snippet: str | None`.
+- F2. `validate_telegram_token` mirrors F1 with the same shape extension.
+- F3. CLI renders the headline + diagnostics block in the same style as existing init prompts (no colour libs).
+- F4. CLI offers retry-after-fix without forcing user to re-enter the key (the value stays in memory until success or abort).
+- F5. Body snippet is truncated to 200 chars and rendered indented (4 spaces) for easy copy-paste.
+- F6. Body snippet is scrubbed of common secret patterns before rendering (Bearer tokens, sk-* keys, the user's own pasted key) : defensive against providers that echo the request back in error bodies.
+
+## 7. Non-functional requirements
+
+- N1. No new runtime dependencies.
+- N2. Init cold-start time unchanged (validators are already lazy-loaded).
+- N3. Tests added for every status branch and the secret-scrub path.
+- N4. Backwards-compatible: existing `ValidationResult` consumers keep working (extend, don't break).
+
+## 8. Acceptance criteria
+
+- AC1. Posting Wei's original guardrails-OpenRouter key in init shows the "404 on /models : issue a new key with all endpoints enabled" guidance (verified manually against a real OpenRouter restricted key, or with a mocked 404).
+- AC2. Posting an empty-credit key shows the 402 message.
+- AC3. Posting a deliberately bad key shows the 401 message.
+- AC4. After any failure, pressing Enter re-runs the validator on the SAME stored value. No re-prompting.
+- AC5. Pressing Ctrl-C at the retry prompt exits cleanly with no partial files written.
+- AC6. Body snippets containing Bearer tokens / sk- keys are redacted.
+- AC7. Unit tests cover each status branch + the retry loop + the secret-scrubber.
+
+## 9. Out of scope (deferred)
+
+- Auto-detecting and pre-validating the base_url shape.
+- Suggesting alternative providers based on the key prefix.
+- Persistent error history (init has no telemetry).
+
+## 10. Open questions for plan-writer
+
+- Where does the secret-scrubber live? Inherit Mira's pattern or build inline? (Recommend: inline minimal function in validators.py; do NOT pull Mira in.)
+- Should retry loop have a max-retry cap? (Recommend: no cap, just allow Ctrl-C; humans are at the keyboard.)
+- Telegram 429 handling shares code with provider 429 : refactor to a shared mapper, or keep per-validator? (Recommend: per-validator dict, deduped only if it becomes noisy.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "kayaclaw"
-version = "0.1.7"
+version = "0.1.8"
 description = "A small, hardened AI agent for Telegram. SQLite memory, your choice of OpenAI-compatible LLM provider."
 # `readme` field intentionally omitted in L0. README.md is created in L6.
 # Add `readme = "README.md"` here as part of L6 release polish.

--- a/tests/test_l7_init_cli.py
+++ b/tests/test_l7_init_cli.py
@@ -1,0 +1,354 @@
+"""Unit tests for agent.init.cli helpers.
+
+Pins the small, deterministic pieces: status->headline mapping, the
+diagnostics renderer, the retry menu, and the retry-after-fix loop.
+The full init flow is exercised separately in test_l7_init_integration.
+"""
+from __future__ import annotations
+
+from collections import deque
+from unittest.mock import patch
+
+import pytest
+
+from agent.init.cli import (
+    _PROVIDER_HEADLINES,
+    _TELEGRAM_HEADLINES,
+    _headline_for,
+    _render_diagnostics,
+    _retry_menu,
+    _retry_validator,
+)
+from agent.init.validators import ValidationResult
+
+
+def _queue(*values: str):
+    q = deque(values)
+
+    def fake(_prompt_text: str = "") -> str:
+        if not q:
+            raise AssertionError(f"input/prompt called past queue; last prompt={_prompt_text!r}")
+        return q.popleft()
+
+    return fake, q
+
+
+def _ok(value_data: dict | None = None) -> ValidationResult:
+    return ValidationResult(
+        ok=True, error=None, data=value_data or {}, status_code=200, endpoint="x", body_snippet="",
+    )
+
+
+def _fail(status: int | None = 401, body: str | None = "bad") -> ValidationResult:
+    return ValidationResult(
+        ok=False, error="rejected", data=None,
+        status_code=status, endpoint="https://api.example.test/v1/models",
+        body_snippet=body,
+    )
+
+
+# headline mapping
+
+
+def test_headline_for_known_provider_status():
+    assert _headline_for(401, _PROVIDER_HEADLINES).startswith("Provider rejected")
+    assert "no usage credit" in _headline_for(402, _PROVIDER_HEADLINES)
+    assert "suspended" in _headline_for(403, _PROVIDER_HEADLINES)
+    assert "wrong base_url" in _headline_for(404, _PROVIDER_HEADLINES)
+    assert "rate-limit" in _headline_for(429, _PROVIDER_HEADLINES)
+
+
+def test_headline_for_5xx_uses_5xx_bucket():
+    assert _headline_for(500, _PROVIDER_HEADLINES) == _PROVIDER_HEADLINES["5xx"]
+    assert _headline_for(503, _PROVIDER_HEADLINES) == _PROVIDER_HEADLINES["5xx"]
+    assert _headline_for(599, _PROVIDER_HEADLINES) == _PROVIDER_HEADLINES["5xx"]
+
+
+def test_headline_for_network_failure_uses_network_sentinel():
+    assert _headline_for(None, _PROVIDER_HEADLINES) == _PROVIDER_HEADLINES["network"]
+    assert _headline_for(None, _TELEGRAM_HEADLINES) == _TELEGRAM_HEADLINES["network"]
+
+
+def test_headline_for_unknown_status_falls_to_other():
+    assert _headline_for(418, _PROVIDER_HEADLINES) == _PROVIDER_HEADLINES["other"]
+    assert _headline_for(305, _PROVIDER_HEADLINES) == _PROVIDER_HEADLINES["other"]
+
+
+def test_telegram_headlines_have_distinct_401_404_share_message():
+    # Spec §5 maps both 401 and 404 to the same Telegram headline.
+    assert _TELEGRAM_HEADLINES[401] == _TELEGRAM_HEADLINES[404]
+
+
+# diagnostics renderer
+
+
+def _failure(
+    status: int | None,
+    endpoint: str | None,
+    snippet: str | None = None,
+) -> ValidationResult:
+    return ValidationResult(
+        ok=False,
+        error="ignored",
+        data=None,
+        status_code=status,
+        endpoint=endpoint,
+        body_snippet=snippet,
+    )
+
+
+def test_render_diagnostics_404_with_snippet(capsys):
+    result = _failure(
+        404,
+        "https://openrouter.ai/api/v1/models",
+        '{"error":"not found","code":"restricted_endpoint"}',
+    )
+    _render_diagnostics(result, _PROVIDER_HEADLINES)
+    out = capsys.readouterr().out
+    assert "wrong base_url" in out
+    assert "HTTP 404 from https://openrouter.ai/api/v1/models" in out
+    assert "restricted_endpoint" in out
+
+
+def test_render_diagnostics_5xx_bucket(capsys):
+    result = _failure(503, "https://api.example.test/v1/models", "Service Unavailable")
+    _render_diagnostics(result, _PROVIDER_HEADLINES)
+    out = capsys.readouterr().out
+    assert "server error" in out
+    assert "HTTP 503" in out
+    assert "Service Unavailable" in out
+
+
+def test_render_diagnostics_network_failure(capsys):
+    result = _failure(None, "https://api.example.test/v1/models", None)
+    _render_diagnostics(result, _PROVIDER_HEADLINES)
+    out = capsys.readouterr().out
+    assert "Network failure" in out
+    assert "api.example.test" in out
+    # No "HTTP <num>" line when status is None.
+    assert "HTTP " not in out
+
+
+def test_render_diagnostics_no_snippet(capsys):
+    result = _failure(401, "https://api.example.test/v1/models", None)
+    _render_diagnostics(result, _PROVIDER_HEADLINES)
+    out = capsys.readouterr().out
+    assert "Provider rejected" in out
+    # Body block should be absent when snippet is None or empty.
+    lines = out.strip().splitlines()
+    indented = [ln for ln in lines if ln.startswith("      ")]
+    assert indented == []
+
+
+def test_render_diagnostics_attempt_counter(capsys):
+    result = _failure(429, "https://api.example.test/v1/models", None)
+    _render_diagnostics(result, _PROVIDER_HEADLINES, attempt=3)
+    out = capsys.readouterr().out
+    assert "(attempt 3)" in out
+
+
+def test_render_diagnostics_no_attempt_omits_counter(capsys):
+    result = _failure(429, "https://api.example.test/v1/models", None)
+    _render_diagnostics(result, _PROVIDER_HEADLINES)
+    out = capsys.readouterr().out
+    assert "attempt" not in out
+
+
+def test_render_diagnostics_multiline_snippet_indented(capsys):
+    result = _failure(
+        500,
+        "https://api.example.test/v1/models",
+        "line one\nline two\nline three",
+    )
+    _render_diagnostics(result, _PROVIDER_HEADLINES)
+    out = capsys.readouterr().out
+    assert "      line one" in out
+    assert "      line two" in out
+    assert "      line three" in out
+
+
+def test_render_diagnostics_telegram_uses_telegram_headlines(capsys):
+    result = _failure(
+        401,
+        "https://api.telegram.org/bot12345:abc/getMe",
+        '{"ok":false,"description":"Unauthorized"}',
+    )
+    _render_diagnostics(result, _TELEGRAM_HEADLINES)
+    out = capsys.readouterr().out
+    assert "Telegram rejected" in out
+    assert "Unauthorized" in out
+
+
+# retry menu
+
+
+@pytest.mark.parametrize("typed,expected", [
+    ("", "r"),
+    ("r", "r"),
+    ("R", "r"),
+    ("n", "n"),
+    ("N", "n"),
+    ("q", "q"),
+    ("Q", "q"),
+])
+def test_retry_menu_accepts_canonical_inputs(typed, expected, capsys):
+    fake, _q = _queue(typed)
+    with patch("agent.init.cli._prompt", side_effect=fake):
+        assert _retry_menu() == expected
+
+
+def test_retry_menu_reprompts_on_unknown(capsys):
+    fake, _q = _queue("x", "huh", "r")
+    with patch("agent.init.cli._prompt", side_effect=fake):
+        assert _retry_menu() == "r"
+    out = capsys.readouterr().out
+    # Two unknown inputs -> two reprompt messages.
+    assert out.count("Please type r, n, or q.") == 2
+
+
+# retry-after-fix loop
+
+
+def test_retry_validator_succeeds_on_first_try(capsys):
+    val_responses = deque([_ok()])
+
+    def validator(_v: str) -> ValidationResult:
+        return val_responses.popleft()
+
+    fake, _q = _queue("paste-value")
+    with patch("agent.init.cli._prompt", side_effect=fake):
+        value, result = _retry_validator(
+            "Paste key: ", validator, _PROVIDER_HEADLINES, prompter=fake,
+        )
+    assert value == "paste-value"
+    assert result.ok is True
+
+
+def test_retry_validator_same_value_after_fix_succeeds(capsys):
+    """[r] reuses the prior value -> simulates user fixing upstream and retrying."""
+    val_responses = deque([_fail(), _ok()])
+
+    def validator(v: str) -> ValidationResult:
+        return val_responses.popleft()
+
+    # First call: prompter for initial value; second call: menu returns 'r'.
+    prompter, _q1 = _queue("the-key")
+    menu, _q2 = _queue("r")
+    with patch("agent.init.cli._prompt", side_effect=menu):
+        value, result = _retry_validator(
+            "Paste key: ", validator, _PROVIDER_HEADLINES, prompter=prompter,
+        )
+    assert value == "the-key"
+    assert result.ok is True
+
+
+def test_retry_validator_new_value_after_failure(capsys):
+    """[n] re-prompts and validator sees a fresh value."""
+    val_responses = deque([_fail(), _ok()])
+    seen = []
+
+    def validator(v: str) -> ValidationResult:
+        seen.append(v)
+        return val_responses.popleft()
+
+    prompter, _q1 = _queue("first-bad", "second-good")
+    menu, _q2 = _queue("n")
+    with patch("agent.init.cli._prompt", side_effect=menu):
+        value, result = _retry_validator(
+            "Paste key: ", validator, _PROVIDER_HEADLINES, prompter=prompter,
+        )
+    assert seen == ["first-bad", "second-good"]
+    assert value == "second-good"
+    assert result.ok is True
+
+
+def test_retry_validator_quits_raises_keyboard_interrupt():
+    """[q] raises KeyboardInterrupt so main() can clean-exit."""
+    val_responses = deque([_fail()])
+
+    def validator(_v: str) -> ValidationResult:
+        return val_responses.popleft()
+
+    prompter, _q1 = _queue("key")
+    menu, _q2 = _queue("q")
+    with patch("agent.init.cli._prompt", side_effect=menu):
+        with pytest.raises(KeyboardInterrupt):
+            _retry_validator(
+                "Paste key: ", validator, _PROVIDER_HEADLINES, prompter=prompter,
+            )
+
+
+def test_retry_validator_no_cap_seven_failures_then_success():
+    """No attempt cap: seven fails then a success works."""
+    val_responses = deque([_fail()] * 7 + [_ok()])
+
+    def validator(_v: str) -> ValidationResult:
+        return val_responses.popleft()
+
+    prompter, _q1 = _queue("key")
+    menu, _q2 = _queue("r", "r", "r", "r", "r", "r", "r")
+    with patch("agent.init.cli._prompt", side_effect=menu):
+        value, result = _retry_validator(
+            "Paste key: ", validator, _PROVIDER_HEADLINES, prompter=prompter,
+        )
+    assert result.ok is True
+
+
+def test_retry_validator_initial_value_skips_first_prompt():
+    """initial_value short-circuits the first prompter call.
+
+    Simulates the early-happy-path: user already pasted a key at the
+    top of _step_provider; that key flows in as initial_value and gets
+    validated without re-prompting.
+    """
+    val_responses = deque([_ok()])
+
+    def validator(v: str) -> ValidationResult:
+        return val_responses.popleft()
+
+    def prompter(_p: str) -> str:
+        raise AssertionError("prompter should not be called when initial_value is set")
+
+    value, result = _retry_validator(
+        "Paste key: ", validator, _PROVIDER_HEADLINES,
+        prompter=prompter, initial_value="pre-pasted-key",
+    )
+    assert value == "pre-pasted-key"
+    assert result.ok is True
+
+
+def test_retry_validator_initial_value_then_fail_then_new(capsys):
+    """Early-happy-path regression: initial_value fails, user picks [n], gives new value."""
+    val_responses = deque([_fail(), _ok()])
+    seen = []
+
+    def validator(v: str) -> ValidationResult:
+        seen.append(v)
+        return val_responses.popleft()
+
+    prompter, _q1 = _queue("user-types-replacement")
+    menu, _q2 = _queue("n")
+    with patch("agent.init.cli._prompt", side_effect=menu):
+        value, result = _retry_validator(
+            "Paste key: ", validator, _PROVIDER_HEADLINES,
+            prompter=prompter, initial_value="pre-pasted-key",
+        )
+    assert seen == ["pre-pasted-key", "user-types-replacement"]
+    assert value == "user-types-replacement"
+
+
+def test_retry_validator_renders_attempt_counter(capsys):
+    val_responses = deque([_fail(), _fail(), _ok()])
+
+    def validator(_v: str) -> ValidationResult:
+        return val_responses.popleft()
+
+    prompter, _q1 = _queue("key")
+    menu, _q2 = _queue("r", "r")
+    with patch("agent.init.cli._prompt", side_effect=menu):
+        _retry_validator(
+            "Paste key: ", validator, _PROVIDER_HEADLINES, prompter=prompter,
+        )
+    out = capsys.readouterr().out
+    assert "(attempt 1)" in out
+    assert "(attempt 2)" in out

--- a/tests/test_l7_init_integration.py
+++ b/tests/test_l7_init_integration.py
@@ -40,8 +40,8 @@ class _Resp:
     def __exit__(self, *exc: Any) -> None:
         return None
 
-    def read(self) -> bytes:
-        return self._body
+    def read(self, n: int | None = None) -> bytes:
+        return self._body if n is None or n < 0 else self._body[:n]
 
 
 def _ok(payload: dict) -> _Resp:
@@ -237,10 +237,15 @@ def test_happy_path_custom_provider(chdir_tmp: Path, fast_time, docker_present):
 
 
 def test_telegram_retry_then_success(chdir_tmp: Path, fast_time, docker_present):
+    # Between attempts the retry menu prompts r/n/q. Test pipes "n"
+    # (new value) so each subsequent attempt re-prompts and gets a
+    # different value from the queue.
     fake_input, _q = _input_queue(
         "sk-or-key", "",
         "bad1",                  # first telegram attempt (will 401)
+        "n",                     # retry menu: new value
         "bad2",                  # second attempt (will 401)
+        "n",                     # retry menu: new value
         "good:token",            # third attempt
         "",                      # accept chat id
     )
@@ -263,10 +268,12 @@ def test_telegram_retry_then_success(chdir_tmp: Path, fast_time, docker_present)
 
 
 def test_provider_retry_then_success(chdir_tmp: Path, fast_time, docker_present):
+    # "n" between attempts to indicate "paste a new value".
     fake_input, _q = _input_queue(
         "",            # press Enter for list
         "1",           # OpenRouter
         "bad-key",     # attempt 1 (401)
+        "n",           # retry menu: new value
         "good-key",    # attempt 2 (200)
         "tg:token", "",
     )
@@ -283,25 +290,27 @@ def test_provider_retry_then_success(chdir_tmp: Path, fast_time, docker_present)
     assert rc == 0
 
 
-# Case 7: three Telegram failures -> sys.exit(1) and no files
+# Case 7: user [q]uits after Telegram failures -> rc=1 and no files
+# (no built-in attempt cap; abort is user-driven via the [q] menu)
 
 
-def test_three_telegram_failures_exits_no_files(chdir_tmp: Path, fast_time, docker_present):
+def test_user_quits_after_telegram_failures_no_files(chdir_tmp: Path, fast_time, docker_present):
     fake_input, _q = _input_queue(
         "sk-or-key", "",
-        "bad1", "bad2", "bad3",
+        "bad1",                  # attempt 1 (401)
+        "n",                     # menu: new value
+        "bad2",                  # attempt 2 (401)
+        "q",                     # menu: quit
     )
     val_responses = [
         _models_ok(),
         _http_err(401, {"ok": False}),
         _http_err(401, {"ok": False}),
-        _http_err(401, {"ok": False}),
     ]
     with patch("builtins.input", side_effect=fake_input), patch("agent.init.cli.getpass.getpass", side_effect=fake_input), \
          patch("urllib.request.urlopen", side_effect=_script_urlopen(val_responses)):
-        with pytest.raises(SystemExit) as exc_info:
-            cli_mod.main()
-    assert exc_info.value.code == 1
+        rc = cli_mod.main()
+    assert rc == 1
     assert not (chdir_tmp / ".env").exists()
     assert not (chdir_tmp / "config.yaml").exists()
 

--- a/tests/test_l7_init_validators.py
+++ b/tests/test_l7_init_validators.py
@@ -14,6 +14,8 @@ from unittest.mock import patch
 import pytest
 
 from agent.init.validators import (
+    BODY_SNIPPET_MAX_CHARS,
+    _scrub_secrets,
     detect_provider_from_key,
     validate_provider_key,
     validate_telegram_token,
@@ -33,8 +35,8 @@ class _FakeResponse:
     def __exit__(self, *exc: Any) -> None:
         return None
 
-    def read(self) -> bytes:
-        return self._body
+    def read(self, n: int | None = None) -> bytes:
+        return self._body if n is None or n < 0 else self._body[:n]
 
 
 def _ok_response(payload: dict) -> _FakeResponse:
@@ -231,3 +233,171 @@ def test_detect_provider_from_key(key, expected):
 def test_detect_provider_openrouter_wins_over_openai_prefix():
     # sk-or-* must NOT classify as openai-suspect even though sk- is a prefix.
     assert detect_provider_from_key("sk-or-v1-xxxxx") == "openrouter"
+
+
+# diagnostic fields (status_code, endpoint, body_snippet)
+
+
+def test_provider_success_populates_status_endpoint_snippet():
+    payload = {"data": []}
+    with patch("agent.init.validators.urllib.request.urlopen", return_value=_ok_response(payload)):
+        result = validate_provider_key("https://api.example.test/v1", "sk-abc")
+    assert result.ok is True
+    assert result.status_code == 200
+    assert result.endpoint == "https://api.example.test/v1/models"
+    assert result.body_snippet is not None  # may be "" if body was empty, but field exists
+
+
+def test_provider_401_populates_diagnostics():
+    with patch(
+        "agent.init.validators.urllib.request.urlopen",
+        side_effect=_http_error(401, {"error": "bad key"}),
+    ):
+        result = validate_provider_key("https://api.example.test/v1", "sk-abc")
+    assert result.ok is False
+    assert result.status_code == 401
+    assert result.endpoint == "https://api.example.test/v1/models"
+    assert "bad key" in (result.body_snippet or "")
+
+
+def test_provider_404_populates_diagnostics():
+    """Wei's OpenRouter guardrails case: 404 on /models with a body."""
+    with patch(
+        "agent.init.validators.urllib.request.urlopen",
+        side_effect=_http_error(404, {"error": "not found", "code": "restricted_endpoint"}),
+    ):
+        result = validate_provider_key("https://openrouter.ai/api/v1", "sk-or-v1-xxx")
+    assert result.ok is False
+    assert result.status_code == 404
+    assert result.endpoint == "https://openrouter.ai/api/v1/models"
+    assert "restricted_endpoint" in (result.body_snippet or "")
+
+
+def test_provider_network_failure_endpoint_set_status_none():
+    with patch(
+        "agent.init.validators.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("dns error"),
+    ):
+        result = validate_provider_key("https://api.example.test/v1", "sk-abc")
+    assert result.ok is False
+    assert result.status_code is None
+    assert result.endpoint == "https://api.example.test/v1/models"
+    assert result.body_snippet is None
+
+
+def test_telegram_401_populates_body_snippet():
+    """Regression: the 401/404 branch used to discard the body before diagnostics shipped."""
+    with patch(
+        "agent.init.validators.urllib.request.urlopen",
+        side_effect=_http_error(401, {"ok": False, "description": "Unauthorized"}),
+    ):
+        result = validate_telegram_token("12345:fake-bot-token-with-30-or-more-chars")
+    assert result.ok is False
+    assert result.status_code == 401
+    assert result.endpoint == "https://api.telegram.org/bot12345:fake-bot-token-with-30-or-more-chars/getMe"
+    assert "Unauthorized" in (result.body_snippet or "")
+
+
+def test_telegram_404_populates_body_snippet():
+    with patch(
+        "agent.init.validators.urllib.request.urlopen",
+        side_effect=_http_error(404, {"ok": False, "description": "Not Found"}),
+    ):
+        result = validate_telegram_token("99999:fake-bot-token-with-30-or-more-chars")
+    assert result.ok is False
+    assert result.status_code == 404
+    assert "Not Found" in (result.body_snippet or "")
+
+
+def test_telegram_success_populates_diagnostics():
+    payload = {"ok": True, "result": {"id": 1, "username": "bot"}}
+    with patch("agent.init.validators.urllib.request.urlopen", return_value=_ok_response(payload)):
+        result = validate_telegram_token("123:abc")
+    assert result.ok is True
+    assert result.status_code == 200
+    assert "api.telegram.org" in (result.endpoint or "")
+
+
+def test_body_snippet_capped_at_max_chars():
+    """Body snippet is capped at BODY_SNIPPET_MAX_CHARS; oversized bodies are truncated."""
+    big_body = ("X" * (BODY_SNIPPET_MAX_CHARS + 200)).encode("utf-8")
+    err = urllib.error.HTTPError(
+        url="http://e.test", code=500, msg="err",
+        hdrs=None, fp=io.BytesIO(big_body),  # type: ignore[arg-type]
+    )
+    with patch("agent.init.validators.urllib.request.urlopen", side_effect=err):
+        result = validate_provider_key("https://api.example.test/v1", "sk-abc")
+    assert result.body_snippet is not None
+    assert len(result.body_snippet) <= BODY_SNIPPET_MAX_CHARS
+
+
+# secret scrubber
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "sk-abc1234567890abcdef",
+        "gsk_abc123def456ghi789jklmno",
+        "Bearer abc123def456ghi789jklmno",
+        "xoxa-abcdef1234567890",
+        "1234567890:AAFakeTelegramTokenWith30PlusChars_xyz",
+    ],
+)
+def test_scrub_generic_patterns(secret: str):
+    out = _scrub_secrets(f"prefix {secret} suffix")
+    assert secret not in out
+    assert "[REDACTED]" in out
+
+
+def test_scrub_env_assignment_pattern():
+    out = _scrub_secrets("API_KEY=supersecretvalue123")
+    assert "supersecretvalue123" not in out
+    assert "[REDACTED]" in out
+
+
+def test_scrub_idempotent():
+    once = _scrub_secrets("sk-abc1234567890abcdef something")
+    twice = _scrub_secrets(once)
+    assert once == twice
+
+
+def test_scrub_leaves_clean_text_alone():
+    out = _scrub_secrets("Provider returned HTTP 404. Not found.")
+    assert out == "Provider returned HTTP 404. Not found."
+
+
+def test_scrub_also_redact_catches_custom_keys():
+    """A DeepInfra-shaped key (no published prefix) leaked in the body
+    must be redacted via the also_redact list."""
+    deepinfra_key = "0123456789abcdef0123456789abcdef"  # 32 chars, no prefix
+    body = f'{{"error":"Bearer {deepinfra_key} is invalid"}}'
+    out = _scrub_secrets(body, also_redact=[deepinfra_key])
+    assert deepinfra_key not in out
+    assert "[REDACTED]" in out
+
+
+def test_scrub_also_redact_skips_short_literals():
+    """A 1-char also_redact value would blanket the body. Floor is 8 chars."""
+    out = _scrub_secrets("the quick brown fox", also_redact=["x"])
+    # "x" is too short to redact; should appear intact.
+    assert "fox" in out
+
+
+def test_scrub_handles_empty_input():
+    assert _scrub_secrets("") == ""
+    assert _scrub_secrets("", also_redact=["whatever"]) == ""
+
+
+def test_provider_snippet_redacts_user_key_in_body():
+    """The user's pasted key, echoed in an error body, must not leak."""
+    deepinfra_key = "0123456789abcdef0123456789abcdef"
+    err_body = {"error": f"key {deepinfra_key} not authorised"}
+    with patch(
+        "agent.init.validators.urllib.request.urlopen",
+        side_effect=_http_error(401, err_body),
+    ):
+        result = validate_provider_key("https://api.deepinfra.com/v1/openai", deepinfra_key)
+    assert result.body_snippet is not None
+    assert deepinfra_key not in result.body_snippet
+    assert "[REDACTED]" in result.body_snippet


### PR DESCRIPTION
## Summary

When init's provider key or Telegram token validation fails, the user now sees a structured diagnostic:
- A one-line headline mapped from the HTTP status (401 = bad key, 402 = no credit, 404 = wrong base_url or restricted endpoints, 429 = rate-limited, 5xx, network).
- The endpoint that was hit, so they can verify they typed the right base_url.
- The first 500 chars of the provider's response body, indented and with secrets scrubbed, so they can copy-paste the upstream error if they need to ask for help.

A short `[r]/[n]/[q]` menu replaces the old hard 3-attempt cap: retry the same value once you've fixed the upstream issue, paste a new value, or quit. Ctrl-C and `[q]` both produce a clean exit with no partial files written.

The detected-prefix happy path (e.g. `sk-or-...`) now routes through the same retry loop, so a key that pattern-matches OpenRouter but fails validation gets the same diagnostics as the picker path. Picker fallback now requires an explicit `[q]`.

## What changed

- `agent/init/validators.py`: `ValidationResult` extends with `status_code`, `endpoint`, `body_snippet`. New `_scrub_secrets(text, also_redact=[input_key])` so the user's own pasted key is always redacted from response bodies, even when it doesn't match a standard prefix. Body reads are capped to bound memory.
- `agent/init/cli.py`: status-to-headline mappers for provider and Telegram, `_render_diagnostics()`, `_retry_menu()`, rewritten `_retry_validator()` with the new menu and `initial_value` short-circuit. `main()` catches KeyboardInterrupt for clean exit.
- `tests/test_l7_init_cli.py` (new): unit tests for the headline mapper, renderer, menu, and retry loop.
- `tests/test_l7_init_validators.py`: tests for the new diagnostic fields, secret scrubber (with custom-prefix key redaction), and the Telegram 401/404 body snippet.
- `tests/test_l7_init_integration.py`: existing retry tests updated for the new menu flow; old hard-cap test replaced with a user-driven `[q]` abort test.
- `CHANGELOG.md`, `pyproject.toml` (version), `README.md` (one-line troubleshooting note).
- `docs/spec/SPEC-v0.1.8-provider-errors.md` + `docs/impl/PLAN-v0.1.8-provider-errors.md`.

## Test plan

- [x] Full test suite: 259 passed, 5 skipped, 0 fail.
- [x] All new error branches covered: 401, 402, 403, 404, 429, 5xx, network for provider; 401, 404, 429, 5xx, network for Telegram.
- [x] Secret scrubber: generic regex set + custom-prefix `also_redact` literal redaction tested. Includes Wei's DeepInfra-shape key case.
- [x] Retry loop: `[r]` same-value-after-fix, `[n]` new-value, `[q]` raises KeyboardInterrupt, seven failures then success (no cap), attempt counter rendered.
- [x] Early-happy-path regression: detected-prefix then fail then retry-success now works.
- [x] Em-dash sweep: clean.

## Acceptance criteria from spec

All 7 ACs (AC1-AC7) addressed. See `docs/spec/SPEC-v0.1.8-provider-errors.md` §8.

## Notes

- No new runtime dependencies.
- Init cold-start time unchanged (validators still lazy-loaded).
- `ValidationResult` shape change is backward-compatible (3 new fields are optional with `None` defaults).